### PR TITLE
Intents: no drain before the first sync pull of the session; a binned task counts as existing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -409,6 +409,8 @@ External app writes intent envelope → WebDAV /GLANCE/events/
   → processed envelope files are garbage-collected after 30 days
 ```
 
+With vault sync enabled, no drain runs before the first sync pull of the session has committed (`intents/intentDrainGate.js`, `sync/initialPull.js`): the create handler's guards read local state, and on a device that has been idle that state predates the fleet's completions and tombstones, so a re-delivered create would otherwise recreate a task the fleet had finished with. A pull that never completes releases the drains after three minutes.
+
 Supported intent actions are `create`, `complete`, `open`, and `query`. The tray popup (`?tray`) never polls: it holds a read-only state snapshot and must not consume events before the main window can act on them.
 
 The `intentsEncryptionSetup.js` / `intentsKeyStore.js` modules manage the optional end-to-end encryption key used to protect envelope contents in transit.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1349,7 +1349,7 @@ const DayPlanner = () => {
 
   // WebDAV intent transport — both hooks no-op until configured via intent settings (PR #11).
   useIntentPoller({
-    tasks, unscheduledTasks, recurringTasks, projects,
+    tasks, unscheduledTasks, recurringTasks, recycleBin, projects,
     setTasks, setUnscheduledTasks, setRecurringTasks,
     goals, addGoal, updateGoal, deleteGoal,
     navigate: tab => {
@@ -1364,7 +1364,7 @@ const DayPlanner = () => {
   // WebDAV poller; no-ops unless DB intents is enabled (its own flag + an
   // inherited vault connection). Same context shape as useIntentPoller.
   const dbIntentContext = {
-    tasks, unscheduledTasks, recurringTasks, projects,
+    tasks, unscheduledTasks, recurringTasks, recycleBin, projects,
     setTasks, setUnscheduledTasks, setRecurringTasks,
     goals, addGoal, updateGoal, deleteGoal,
     navigate: tab => {

--- a/src/intents/dbIntentsTransport.js
+++ b/src/intents/dbIntentsTransport.js
@@ -38,6 +38,7 @@ import {
 } from '@glance-apps/intents';
 import { loadVaultIntentsRootKey } from './intentsKeyStore.js';
 import { handleIntent } from './handleIntent.js';
+import { intentDrainAllowed, INTENT_DRAIN_RETRY_MS } from './intentDrainGate.js';
 import { logActivity } from './intentLog.js';
 import { MULTI_USER_CONFIG_KEY } from './useIntentPoller.js';
 import {
@@ -422,6 +423,9 @@ async function routeIncoming(raw, context, opts = {}) {
 export async function pollDbIntents(context, opts = {}) {
   const connection = opts.connection ?? getDbIntentsConnection();
   if (!connection) return;
+  // Not before the first sync pull of the session (intents/intentDrainGate.js).
+  // Covers every entry: the poller, focus, and the SSE-triggered drain.
+  if (!(opts.skipDrainGate || intentDrainAllowed())) return;
 
   const client = intentsClientFor(connection, opts.vaultFetch);
   // Test seam: lets tests drive the three-way model deterministically. Defaults
@@ -585,6 +589,11 @@ export function useDbIntentPoller(context, opts = {}) {
 
     const runPoll = async () => {
       if (destroyed) return;
+      if (!intentDrainAllowed()) {
+        // Held for the first sync pull: look again soon, not a full interval.
+        timerId = setTimeout(runPoll, INTENT_DRAIN_RETRY_MS);
+        return;
+      }
       try {
         // Self-heal the vault intents key before draining so inbound rows can
         // decrypt instead of throwing KeyUnavailableError. Best-effort/no-throw.

--- a/src/intents/handleIntent.js
+++ b/src/intents/handleIntent.js
@@ -253,6 +253,7 @@ async function handleCreate(payload, context) {
     tasks = [],
     unscheduledTasks = [],
     recurringTasks = [],
+    recycleBin = [],
     setTasks,
     setUnscheduledTasks,
     setRecurringTasks,
@@ -374,10 +375,14 @@ async function handleCreate(payload, context) {
       return ok({ task_id: completedExisting.id, warning: 'Task already completed; ignored re-delivered create' });
     }
   }
+  // A task in the recycle bin is neither live nor tombstoned (the tombstone
+  // is written when the bin is emptied), so it counts as existing here: a
+  // re-delivered create must not bring back what the user binned.
   const idExists =
     tasks.some(t => t.id === taskId) ||
     unscheduledTasks.some(t => t.id === taskId) ||
-    recurringTasks.some(t => t.id === taskId);
+    recurringTasks.some(t => t.id === taskId) ||
+    recycleBin.some(t => t && t.id === taskId);
   const isTombstoned = (() => {
     if (deletedTaskIds) return !!deletedTaskIds[taskId];
     try {

--- a/src/intents/handleIntent.test.js
+++ b/src/intents/handleIntent.test.js
@@ -580,6 +580,7 @@ function makeCapture(initial = {}) {
     get _inbox() { return state.unscheduledTasks; },
     get _recurring() { return state.recurringTasks; },
     ...(initial.deletedTaskIds ? { deletedTaskIds: initial.deletedTaskIds } : {}),
+    ...(initial.recycleBin ? { recycleBin: initial.recycleBin } : {}),
   };
   return ctx;
 }
@@ -746,6 +747,25 @@ describe('handleIntent create execution', () => {
       title: 'Chore',
       source_app: 'app.lastglance',
       source_entity_id: 'chore_44',
+      due: '2026-06-01',
+    }, ctx);
+
+    expect(r.success).toBe(true);
+    expect(r.warning).toContain('ignored re-delivered create');
+    expect(ctx._tasks).toHaveLength(0);
+    expect(ctx._inbox).toHaveLength(0);
+  });
+
+  it('no-ops a re-delivered create whose task sits in the recycle bin (binned, not yet tombstoned)', async () => {
+    const key = await createKey('app.lastglance', 'chore_45', '2026-06-01');
+    const { deterministicTaskId } = await import('./handleIntent.js');
+    const binnedId = await deterministicTaskId(key);
+    const ctx = makeCapture({ recycleBin: [{ id: binnedId, title: 'Chore', deletedAt: '2026-06-02T00:00:00Z' }] });
+
+    const r = await handleIntent('create', {
+      title: 'Chore',
+      source_app: 'app.lastglance',
+      source_entity_id: 'chore_45',
       due: '2026-06-01',
     }, ctx);
 

--- a/src/intents/intentDrainGate.js
+++ b/src/intents/intentDrainGate.js
@@ -1,0 +1,36 @@
+// May an intent drain run now? Pure; the stateful inputs live in
+// sync/initialPull.js and sync/vaultConfig.js.
+//
+// With vault sync on, a drain must not run before the first pull of the
+// session has committed: the create handler's guards read local state, and
+// on a device that has been idle that state predates the fleet's completions
+// and tombstones (see sync/initialPull.js). A pull that never completes must
+// not hold intents forever, so after INTENT_DRAIN_WAIT_MAX_MS the drain runs
+// anyway; by then the sync channel has reported its own failure.
+
+import { isVaultEnabled } from '../sync/vaultConfig.js';
+import { initialPullCompleted, msSinceAppStart } from '../sync/initialPull.js';
+
+export const INTENT_DRAIN_WAIT_MAX_MS = 3 * 60 * 1000;
+export const INTENT_DRAIN_RETRY_MS = 15 * 1000;
+
+/** @returns {{ allowed: boolean, reason: 'no-vault-sync'|'pulled'|'waited-out'|'awaiting-first-pull' }} */
+export function intentDrainDecision({ vaultSyncEnabled, pullDone, msSinceStart }) {
+  if (!vaultSyncEnabled) return { allowed: true, reason: 'no-vault-sync' };
+  if (pullDone) return { allowed: true, reason: 'pulled' };
+  if (msSinceStart >= INTENT_DRAIN_WAIT_MAX_MS) return { allowed: true, reason: 'waited-out' };
+  return { allowed: false, reason: 'awaiting-first-pull' };
+}
+
+let announced = false;
+/** The live decision. Logs the hold once per session. */
+export function intentDrainAllowed() {
+  const d = intentDrainDecision({
+    vaultSyncEnabled: isVaultEnabled(), pullDone: initialPullCompleted(), msSinceStart: msSinceAppStart(),
+  });
+  if (!d.allowed && !announced) {
+    announced = true;
+    console.info('[intent] holding the first drain until the first sync pull of this session completes');
+  }
+  return d.allowed;
+}

--- a/src/intents/intentDrainGate.test.js
+++ b/src/intents/intentDrainGate.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { intentDrainDecision, INTENT_DRAIN_WAIT_MAX_MS } from './intentDrainGate.js';
+
+describe('intentDrainDecision', () => {
+  it('runs freely without vault sync', () => {
+    expect(intentDrainDecision({ vaultSyncEnabled: false, pullDone: false, msSinceStart: 0 })).toEqual({ allowed: true, reason: 'no-vault-sync' });
+  });
+
+  it('THE STALE-TASK ITEM: with vault sync on, holds until the first pull has committed', () => {
+    expect(intentDrainDecision({ vaultSyncEnabled: true, pullDone: false, msSinceStart: 5_000 })).toEqual({ allowed: false, reason: 'awaiting-first-pull' });
+    expect(intentDrainDecision({ vaultSyncEnabled: true, pullDone: true, msSinceStart: 5_000 })).toEqual({ allowed: true, reason: 'pulled' });
+  });
+
+  it('a pull that never completes does not hold intents forever', () => {
+    expect(intentDrainDecision({ vaultSyncEnabled: true, pullDone: false, msSinceStart: INTENT_DRAIN_WAIT_MAX_MS })).toEqual({ allowed: true, reason: 'waited-out' });
+  });
+});

--- a/src/intents/useIntentPoller.js
+++ b/src/intents/useIntentPoller.js
@@ -21,6 +21,7 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 // intents because processing an event would advance the cursor and consume
 // the event before the main window can act on it.
 import { isTrayMode } from '../utils/trayMode.js';
+import { intentDrainAllowed, INTENT_DRAIN_RETRY_MS } from './intentDrainGate.js';
 
 // Module-level lock: prevents React StrictMode's double-mount from running two
 // concurrent poll() calls, which would both see cursor=null and duplicate tasks.
@@ -609,6 +610,12 @@ export function useIntentPoller(context) {
 
     const runPoll = async () => {
       if (destroyed) return;
+      if (!intentDrainAllowed()) {
+        // Held for the first sync pull of the session (intentDrainGate.js):
+        // look again soon, not a full interval.
+        pollTimerId = setTimeout(runPoll, INTENT_DRAIN_RETRY_MS);
+        return;
+      }
       try {
         await poll(config, contextRef.current);           // WebDAV (no-ops if not configured)
         if (isIcloudIntentsEnabled()) {

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -33,6 +33,7 @@ import { createDbSyncEngine, clearDbRootKey, initDbRootKey, decryptEntity, isSup
 // client alone, constructible without the engine, for the own-ack wrapper below.
 import { createVaultClient } from '@glance-apps/sync/src/vaultClient.js';
 import { getVaultConfig, isVaultEnabled } from './vaultConfig.js';
+import { markInitialPullComplete } from './initialPull.js';
 import { getDeviceId } from './deviceId.js';
 import {
   getLocalEntity as adapterGetLocalEntity,
@@ -1165,6 +1166,9 @@ export function createDbEngine(callbacks = {}) {
       } else {
         breaker.onSuccess();
       }
+      // The first committed pull of the session releases the intent drains
+      // (sync/initialPull.js): their guards can now see the fleet's state.
+      markInitialPullComplete();
       callbacks.onStatusChange?.('success');
       return {
         applied: pull?.applied ?? 0, skipped: pull?.skipped ?? 0, skippedEntityIds: pull?.skippedEntityIds ?? [],

--- a/src/sync/initialPull.js
+++ b/src/sync/initialPull.js
@@ -10,15 +10,20 @@
 // the fleet's completion or tombstone. The drains now wait for the first
 // pull of the session when vault sync is on.
 
+// The pulled rows reach React state a beat after the cycle returns, and the
+// SSE nudge on a fresh launch drains sync and then intents back to back, so
+// "completed" is reported only once the commit has had time to render.
+export const INITIAL_PULL_SETTLE_MS = 2000;
+
 let initialPullCompletedAt = 0;
 const appStartedAt = Date.now();
 
-export function markInitialPullComplete() {
-  if (!initialPullCompletedAt) initialPullCompletedAt = Date.now();
+export function markInitialPullComplete(now = Date.now()) {
+  if (!initialPullCompletedAt) initialPullCompletedAt = now;
 }
 
-export function initialPullCompleted() {
-  return initialPullCompletedAt > 0;
+export function initialPullCompleted(now = Date.now()) {
+  return initialPullCompletedAt > 0 && now - initialPullCompletedAt >= INITIAL_PULL_SETTLE_MS;
 }
 
 export function msSinceAppStart(now = Date.now()) {

--- a/src/sync/initialPull.js
+++ b/src/sync/initialPull.js
@@ -1,0 +1,31 @@
+// Whether this session has completed its first DB sync cycle, and how long the
+// app has been up. Read by the intent drains (intents/intentDrainGate.js).
+//
+// Field item, 2026-09-08: tasks that lastGLANCE had created through
+// GLANCEintents reappeared on a device that had been idle for a while. The
+// intent pollers drain on mount, before the first sync pull, and the create
+// handler's guards (already exists, already completed, tombstoned) read local
+// state that is still as the idle device left it. A re-delivered create then
+// passed every guard, was stamped with the moment of creation, and outranked
+// the fleet's completion or tombstone. The drains now wait for the first
+// pull of the session when vault sync is on.
+
+let initialPullCompletedAt = 0;
+const appStartedAt = Date.now();
+
+export function markInitialPullComplete() {
+  if (!initialPullCompletedAt) initialPullCompletedAt = Date.now();
+}
+
+export function initialPullCompleted() {
+  return initialPullCompletedAt > 0;
+}
+
+export function msSinceAppStart(now = Date.now()) {
+  return now - appStartedAt;
+}
+
+/** Test seam. */
+export function _resetInitialPullForTests() {
+  initialPullCompletedAt = 0;
+}

--- a/src/sync/initialPull.test.js
+++ b/src/sync/initialPull.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { markInitialPullComplete, initialPullCompleted, INITIAL_PULL_SETTLE_MS, _resetInitialPullForTests } from './initialPull.js';
+
+describe('initialPull', () => {
+  beforeEach(() => _resetInitialPullForTests());
+
+  it('is not complete before any cycle has committed', () => {
+    expect(initialPullCompleted(10_000)).toBe(false);
+  });
+
+  it('reports complete only once the commit has had time to reach React state', () => {
+    markInitialPullComplete(10_000);
+    expect(initialPullCompleted(10_000)).toBe(false);                             // the same beat as the cycle's return
+    expect(initialPullCompleted(10_000 + INITIAL_PULL_SETTLE_MS - 1)).toBe(false);
+    expect(initialPullCompleted(10_000 + INITIAL_PULL_SETTLE_MS)).toBe(true);
+  });
+
+  it('keeps the first mark; later cycles do not move it', () => {
+    markInitialPullComplete(10_000);
+    markInitialPullComplete(50_000);
+    expect(initialPullCompleted(10_000 + INITIAL_PULL_SETTLE_MS)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The lastGLANCE stale-task item. The field case, 2026-09-08: lastGLANCE sends a task to dayGLANCE; it is scheduled and completed on the active devices; a phone or tablet that has been idle is opened, and the completion is wiped, with the task back in the all-day area as when the intent first arrived. The recycle bin is not involved.

**Mechanism.** Intent rows live 30 days on the server and every device consumes them by its own cursor, so an idle device replays weeks of creates on its first drain. Both intent pollers drain on mount, before the first sync pull. The create handler already refuses a create whose task exists, is completed, or is tombstoned, but on the idle device those guards read local state that predates the task entirely. The create passes, the task is recreated all-day and uncompleted, stamped with the moment of creation, and that stamp outranks the completion on the next push. The guards were right; they were consulted too early.

## Changes

- **`src/sync/initialPull.js`, `src/intents/intentDrainGate.js`.** With vault sync on, no drain runs until the first sync cycle of the session has committed, plus a two-second settle so the pulled rows have reached React state (the SSE nudge on a fresh launch drains sync and then intents back to back). The gate sits inside `pollDbIntents`, covering the poller, focus, and the SSE-triggered drain, and in both pollers' loops, which look again every 15 s while held. A pull that never completes releases the drains after three minutes, by which time the sync channel has reported its own failure. Without vault sync nothing changes.
- **`src/intents/handleIntent.js`**, separate from the field case: a task in the recycle bin is neither live nor tombstoned (the tombstone is written when the bin is emptied), so a re-delivered create could bring it back even on a current device. The guard now counts a binned task as existing; both intent contexts in `App.jsx` pass the bin.
- `ARCHITECTURE.md` intents section records the rule.

## Tests

- `src/sync/initialPull.test.js`: not complete before a cycle; complete only after the settle; the first mark stands.
- `src/intents/intentDrainGate.test.js`: free without vault sync; held until the first pull with it; released after the wait.
- `src/intents/handleIntent.test.js`: a re-delivered create whose task sits in the bin is a no-op, beside the existing tombstone case.
- Intents and sync suites: 44 files, 570 tests before the settle change; the two new files add six. Lint and whitespace clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ