### PR TITLE
Bridge intents: apply to a CRLF note with its own line ending

### DIFF
--- a/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
+++ b/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
@@ -625,6 +625,38 @@ describe('vault task scope, end to end', () => {
     expect(A.state.dailyNotes['2026-09-08']!.lastModified).toBe(rec.lastModified);
   });
 
+  it('20. every intent the plugin applies to a CRLF note leaves it CRLF: state, append, completion log, remove (format-package audit low, follow-up)', async () => {
+    const lf = `# House\n\n- [ ] ${LINE}\n`;
+    await bootWithScopedNote(lf.replace(/\n/g, '\r\n'));
+    const noBareLf = (text: string) => !/[^\r]\n/.test(text) && !text.startsWith('\n');
+    const token = s.text(NOTE)!.match(/\^dg-([a-z0-9]{8})/)![1];
+    // (a) task_state through the real plugin applier.
+    await A.emit('task_state', { path: NOTE, blockId: token, obsidianRawTitle: LINE, completed: true });
+    await s.plugin.transport.drain();
+    expect(s.text(NOTE)).toMatch(/- \[x\] Call the plumber \^dg-[a-z0-9]{8}\r\n/);
+    expect(noBareLf(s.text(NOTE)!)).toBe(true);
+    // (b) task_append and (c) completion_log_append into a CRLF daily note.
+    const DAILY = 'Daily/2026-09-10.md';
+    await s.write(DAILY, '## Tasks\r\n- [ ] Existing\r\n\r\n## Completed\r\n');
+    await A.emit('task_append', {
+      path: DAILY, date: '2026-09-10', heading: '## Tasks', template: '',
+      task: { title: 'Water the plants #obsidian', startTime: null, duration: null, isAllDay: true, date: '2026-09-10', blockId: 'cr1f0001' },
+    });
+    await A.emit('completion_log_append', { path: DAILY, date: '2026-09-10', heading: '## Completed', entry: '- ✅ 09:00 Existing', template: '' });
+    await s.plugin.transport.drain();
+    const daily = s.text(DAILY)!;
+    expect(daily).toContain('- [ ] Water the plants #obsidian ^dg-cr1f0001\r\n');
+    expect(daily).toContain('## Completed\r\n- ✅ 09:00 Existing\r\n');
+    expect(noBareLf(daily)).toBe(true);
+    // (d) task_remove takes the line and nothing else.
+    await A.emit('task_remove', { path: DAILY, blockId: 'cr1f0001', obsidianRawTitle: 'Water the plants #obsidian' });
+    await s.plugin.transport.drain();
+    const after = s.text(DAILY)!;
+    expect(after).not.toContain('Water the plants');
+    expect(after).toContain('- [ ] Existing\r\n');
+    expect(noBareLf(after)).toBe(true);
+  });
+
   it('9. a plugin reload republishes the pairing meta WITH the scope (harness finding)', async () => {
     await bootWithScopedNote();
     s.plugin.reload();

--- a/packages/obsidian-format/src/bridgeStream.js
+++ b/packages/obsidian-format/src/bridgeStream.js
@@ -69,7 +69,7 @@
 // is the crash story — an applier that dies between applying a batch and
 // persisting its applied-ID set simply re-applies as no-ops.
 
-import { updateTaskLines, sortTaskLinesInSection, buildObsidianTaskLine } from './taskLines.js';
+import { updateTaskLines, sortTaskLinesInSection, buildObsidianTaskLine, splitNoteLines } from './taskLines.js';
 import { splitBlockId } from './identity.js';
 import { withCreationFrontmatter } from './frontmatter.js';
 import { renderNoteTemplateSubset } from './projectNotes.js';
@@ -261,7 +261,10 @@ export function applyBridgeIntent(currentText, intent) {
       // stays with dayGLANCE's scan-time policy, which sees the resulting
       // line like any other vault edit.
       if (currentText === null) return { text: null, changed: false };
-      const lines = currentText.split('\n');
+      // Every branch splits and re-joins with the note's OWN line ending
+      // (splitNoteLines): a CRLF note stays CRLF, and no line compares
+      // against a dangling '\r' (format-package audit low, 2026-09-06).
+      const { lines, eol } = splitNoteLines(currentText);
       const updated = updateTaskLines(lines, {
         obsidianRawTitle: intent.obsidianRawTitle,
         completed: intent.completed,
@@ -279,7 +282,7 @@ export function applyBridgeIntent(currentText, intent) {
       const finalLines = intent.taskHeading
         ? sortTaskLinesInSection(lines, intent.taskHeading.trim(), intent.date)
         : lines;
-      const text = finalLines.join('\n');
+      const text = finalLines.join(eol);
       return { text, changed: text !== currentText };
     }
 
@@ -300,7 +303,7 @@ export function applyBridgeIntent(currentText, intent) {
       if (noteTask && currentText === null) return { text: null, changed: false };
       const taskLine = buildObsidianTaskLine(intent.task, intent.date);
       if (currentText !== null) {
-        const existingLines = currentText.split('\n');
+        const existingLines = splitNoteLines(currentText).lines;
         // Block ids are stored bare; the vault token is ^dg-<id> (identity.js).
         // THE REAL CONDITION is whether the line WE WOULD WRITE carries the
         // token (audit fix H3): buildObsidianTaskLine routes the token
@@ -325,7 +328,7 @@ export function applyBridgeIntent(currentText, intent) {
       const base = currentText !== null
         ? currentText
         : dailyNoteCreationBody(intent.template, intent.date, intent.path);
-      const lines = base.split('\n');
+      const { lines, eol } = splitNoteLines(base);
       const heading = intent.heading;
       if (heading && heading.trim()) {
         const headingStr = heading.trim();
@@ -351,7 +354,7 @@ export function applyBridgeIntent(currentText, intent) {
       const sorted = heading && heading.trim() && !noteTask
         ? sortTaskLinesInSection(lines, heading.trim(), intent.date)
         : lines;
-      return { text: sorted.join('\n'), changed: true };
+      return { text: sorted.join(eol), changed: true };
     }
 
     case 'task_remove': {
@@ -363,7 +366,7 @@ export function applyBridgeIntent(currentText, intent) {
       // the line goes; the section, its heading and its other lines are the
       // user's.
       if (currentText === null) return { text: null, changed: false };
-      const lines = currentText.split('\n');
+      const { lines, eol } = splitNoteLines(currentText);
       const wantId = intent.blockId ? String(intent.blockId) : null;
       const wantRaw = typeof intent.obsidianRawTitle === 'string' ? intent.obsidianRawTitle.trim() : null;
       const idx = lines.findIndex((line) => {
@@ -375,7 +378,7 @@ export function applyBridgeIntent(currentText, intent) {
       });
       if (idx === -1) return { text: currentText, changed: false };
       lines.splice(idx, 1);
-      return { text: lines.join('\n'), changed: true };
+      return { text: lines.join(eol), changed: true };
     }
 
     case 'completion_log_append': {
@@ -392,13 +395,13 @@ export function applyBridgeIntent(currentText, intent) {
       // formatter's guarantee; refuse rather than write it.
       if (!entry || entry.includes('\n')) return { text: currentText, changed: false };
       if (currentText !== null) {
-        const landed = currentText.split('\n').some((l) => l.trimEnd() === entry);
+        const landed = splitNoteLines(currentText).lines.some((l) => l.trimEnd() === entry);
         if (landed) return { text: currentText, changed: false };
       }
       const logBase = currentText !== null
         ? currentText
         : dailyNoteCreationBody(intent.template, intent.date, intent.path);
-      const logLines = logBase.split('\n');
+      const { lines: logLines, eol: logEol } = splitNoteLines(logBase);
       const logHeading = (intent.heading || '').trim();
       if (!logHeading) return { text: currentText, changed: false }; // the log always has a home
       const logHeadingIdx = logLines.findIndex((l) => l === logHeading);
@@ -419,7 +422,7 @@ export function applyBridgeIntent(currentText, intent) {
         }
         logLines.splice(insertAt, 0, entry);
       }
-      return { text: logLines.join('\n'), changed: true };
+      return { text: logLines.join(logEol), changed: true };
     }
 
     case 'daily_note_write': {

--- a/packages/obsidian-format/src/bridgeStream.test.js
+++ b/packages/obsidian-format/src/bridgeStream.test.js
@@ -294,6 +294,67 @@ describe('applyBridgeIntent — note tasks (companion §4.3, project routing)', 
 // Every point that CREATES a daily note renders the app's text template
 // through the same subset — `{{date}}`, and `{{title}}` as the note's name
 // — so a template reads the same wherever the note is born.
+describe('applyBridgeIntent — CRLF notes (format-package audit low, 2026-09-06, follow-up)', () => {
+  // The four line-editing branches used to split on a bare LF and join with
+  // LF: on a Windows-ended note every line kept a dangling '\r' for the
+  // comparisons, and the rewritten note came back with mixed endings.
+  const crlf = (lf) => lf.replace(/\n/g, '\r\n');
+  const bareLf = (text) => /[^\r]\n/.test(text) || text.startsWith('\n');
+  const NOTE = crlf('# Day\n\n## Tasks\n- [ ] 09:00 Write report ^dg-abc12345\n- [ ] Other\n');
+  const stateIntent = {
+    type: 'task_state', path: '2026-08-29.md', date: '2026-08-29',
+    obsidianRawTitle: 'Write report', completed: true, startTime: '09:00',
+    duration: null, taskHeading: '## Tasks', blockId: 'abc12345',
+    completedAt: null, completionFormat: null,
+  };
+  const appendIntent = {
+    type: 'task_append', path: '2026-08-29.md', date: '2026-08-29',
+    task: { title: 'New thing #obsidian', startTime: null, duration: null, isAllDay: true, date: '2026-08-29', blockId: 'def67890' },
+    heading: '## Tasks', template: '# My day\n',
+  };
+
+  it('task_state finds the line behind the CR, marks it, and re-joins with CRLF; replay is a no-op', () => {
+    const out = applyBridgeIntent(NOTE, stateIntent);
+    expect(out.changed).toBe(true);
+    expect(out.text).toContain('- [x] 09:00 Write report ^dg-abc12345\r\n');
+    expect(bareLf(out.text)).toBe(false);
+    expect(applyBridgeIntent(out.text, stateIntent).changed).toBe(false);
+  });
+
+  it('task_append inserts a CRLF line under the heading, sorts within the section, and dedupes on replay', () => {
+    const out = applyBridgeIntent(NOTE, appendIntent);
+    expect(out.changed).toBe(true);
+    expect(out.text).toContain('- [ ] New thing #obsidian ^dg-def67890\r\n');
+    expect(bareLf(out.text)).toBe(false);
+    expect(applyBridgeIntent(out.text, appendIntent).changed).toBe(false);
+  });
+
+  it('task_remove matches the block id behind the CR and leaves the rest CRLF', () => {
+    const out = applyBridgeIntent(NOTE, { type: 'task_remove', path: '2026-08-29.md', blockId: 'abc12345', obsidianRawTitle: 'Write report' });
+    expect(out.changed).toBe(true);
+    expect(out.text).not.toContain('Write report');
+    expect(out.text).toContain('- [ ] Other\r\n');
+    expect(bareLf(out.text)).toBe(false);
+    expect(applyBridgeIntent(out.text, { type: 'task_remove', path: '2026-08-29.md', blockId: 'abc12345' }).changed).toBe(false);
+  });
+
+  it('completion_log_append lands under its heading in CRLF and dedupes on replay', () => {
+    const intent = { type: 'completion_log_append', path: '2026-08-29.md', date: '2026-08-29', heading: '## Completed', entry: '- ✅ 12:30 Write report', template: '' };
+    const out = applyBridgeIntent(NOTE, intent);
+    expect(out.changed).toBe(true);
+    expect(out.text).toContain('## Completed\r\n- ✅ 12:30 Write report\r\n');
+    expect(bareLf(out.text)).toBe(false);
+    expect(applyBridgeIntent(out.text, intent).changed).toBe(false);
+  });
+
+  it('an LF note is untouched by the change: same output as before, LF throughout', () => {
+    const lf = '# Day\n\n## Tasks\n- [ ] 09:00 Write report ^dg-abc12345\n- [ ] Other\n';
+    const out = applyBridgeIntent(lf, appendIntent);
+    expect(out.text).not.toContain('\r');
+    expect(out.text).toContain('- [ ] New thing #obsidian ^dg-def67890\n');
+  });
+});
+
 describe('dailyNoteCreationBody / creation through the two daily-note intents', () => {
   it('fills {{date}} and {{title}} (the note name from the path, else the date) and adds the creation frontmatter', () => {
     const body = dailyNoteCreationBody('# {{title}}\n\nToday is {{date}}.\n', '2026-09-10', 'Daily/2026-09-10.md');


### PR DESCRIPTION
## Summary

The follow-up to the 2026-09-06 format-package audit low (#1564). That PR made the parser and the plugin's stamping path keep a Windows-ended note CRLF throughout. The intent applier, `applyBridgeIntent` in `packages/obsidian-format/src/bridgeStream.js`, was left as it was: its four line-editing branches split the note on a bare LF and joined with LF, so on a CRLF note every line kept a dangling carriage return for the comparisons and the rewritten note came back with mixed endings.

## Change

The four branches (task_state and task_retitle, task_append, task_remove, completion_log_append) now go through `splitNoteLines`, the helper #1564 added, and re-join with the note's own ending. That is every split-or-join site in the module; the whole-note writes (daily_note_write, wiki_note_write) replace content and are untouched. What each intent does is unchanged: an LF note produces exactly what it did before.

Only vaults holding CRLF notes are affected. Obsidian writes LF on every platform, so a vault only Obsidian has written never sees this.

## Tests

- `bridgeStream.test.js`: each of the four branches on a CRLF note, with its replay no-op, plus an LF control. 31/31.
- Harness scenario 20 drives all four intents through the real plugin against CRLF notes, a scoped note and a daily note, and checks no bare LF is ever written. 28/28, plugin typecheck clean.
- Lint and whitespace clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_