### PR TITLE
Project and goal note chips use the open book, the app's Obsidian glyph

### DIFF
--- a/src/components/goals/GoalCard.jsx
+++ b/src/components/goals/GoalCard.jsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import { AlertTriangle, Calendar, CircleCheckBig, Edit2, FileText, FolderOpen, Layers, Link2, Plus } from 'lucide-react';
+import { AlertTriangle, BookOpen, Calendar, CircleCheckBig, Edit2, FileText, FolderOpen, Layers, Link2, Plus } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
@@ -90,7 +90,7 @@ const GoalCard = forwardRef(
               title={noteLink.missing ? `Obsidian note missing: ${noteLink.name}` : `Open "${noteLink.name}" in Obsidian`}
               aria-label={noteLink.missing ? 'Obsidian note missing' : 'Open goal note in Obsidian'}
             >
-              {noteLink.missing ? <AlertTriangle size={12} /> : <FileText size={12} />}
+              {noteLink.missing ? <AlertTriangle size={12} /> : <BookOpen size={12} />}
             </button>
           )}
           {(goal.source_app === 'app.lifeglance' || goal.synced_to_lifeglance) && (

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -77,7 +77,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
       title={noteLink.missing ? `Obsidian note missing: ${noteLink.name}` : `Open "${noteLink.name}" in Obsidian`}
       aria-label={noteLink.missing ? 'Obsidian note missing' : 'Open project note in Obsidian'}
     >
-      {noteLink.missing ? <AlertTriangle size={12} /> : <FileText size={12} />}
+      {noteLink.missing ? <AlertTriangle size={12} /> : <BookOpen size={12} />}
     </button>
   );
   const { goals, deleteProject, updateProject, setPlannerProjectId, generateAISubtasks, aiSubtasksLoadingForTask, aiConfig, showGoalsDashboard, enterHyperGlanceMode, isVisibleForUser } = useFeaturesCtx();


### PR DESCRIPTION
## Summary

The chip that opens a project's or goal's linked Obsidian note drew the same document glyph a task's own notes use. The open book already marks Obsidian in task rows and the new-task modals, so the chip now matches, on the project card and the goal card. The amber missing-note warning is unchanged. Lucide has no Obsidian glyph, and their logo is theirs.

Two files, two icons, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_