### PR TITLE
Project task order as a field on the task: syncs on both tiers, survives the Obsidian cycle

### DIFF
--- a/docs/obsidian-buildout-spec.md
+++ b/docs/obsidian-buildout-spec.md
@@ -141,6 +141,22 @@ The Phase 1 section below reflects the delivered design, not a proposal.
   adoption, for a case not yet observed in the field. Revisit with the
   next `@glance-apps/sync` bump.
 
+- **Project note line order following the app's project order (deferred
+  2026-09-08).** The order of a project's unscheduled tasks became a field
+  on each task (`projectOrder`, `utils/projectOrder.js`) after the owner
+  found reorders reverting: the order had been the inbox array's positions,
+  which the DB tier never carried and every Obsidian cycle rebuilt. Ruling:
+  the order is the app's; the linked note keeps its own line order and
+  neither reads nor writes the field. The owner would ideally have the
+  note's Tasks section follow the app's order. What that takes: a
+  `task_reorder` intent that permutes the task lines within one section by
+  block id, emitted by the writeback whenever the project's order changes,
+  applied by the plugin like any other intent; an amendment to the 4.3
+  ruling that a project note's sections are never sorted; and a decision on
+  the reverse direction (a line moved in Obsidian does not move the task in
+  the app under this design). Deferred as a separate commission; the app
+  side is complete without it.
+
 ### 2.6 Field incident record (2026-09-07): the 24-row tombstone replay
 
 Eight daily notes and their sixteen tasks, all deleted from the vault

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -21,6 +21,7 @@ import { dateToString, extractWikilinks, completionTimestamp } from '../../utils
 import { getNextOccurrence } from '../../utils/recurrenceEngine.js';
 import { getActiveHGInstance } from '../../hooks/useHyperGlance.js';
 import { noteLinkOf } from '../../utils/obsidianProjectNotes.js';
+import { sortByProjectOrder, applyProjectReorder } from '../../utils/projectOrder.js';
 import { formatLocalizedDate } from '../../utils/localeFormatting.js';
 
 const toHex = (bgClass) => TAILWIND_TO_HEX[bgClass] || '#3b82f6';
@@ -140,8 +141,9 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
   // Per-goal opt-out: a goal with hideStalled suppresses the badge on its projects.
   const stalled = !!project.goalId && !parentGoal?.hideStalled && !hasHGSession && isProjectStalled(project.id, allTasks, project, recurringTasks);
 
-  // All project tasks: unscheduled (in array order) then scheduled (by date), completed last
-  const projectUnscheduled = unscheduledTasks.filter(t => t.projectId === project.id && !t.archived && isVisibleForUser(t));
+  // All project tasks: unscheduled (by projectOrder, utils/projectOrder.js,
+  // then array order) then scheduled (by date), completed last
+  const projectUnscheduled = sortByProjectOrder(unscheduledTasks.filter(t => t.projectId === project.id && !t.archived && isVisibleForUser(t)));
   const projectScheduled = tasks.filter(t => t.projectId === project.id && !t.archived && isVisibleForUser(t))
     .sort((a, b) => (a.date || '').localeCompare(b.date || ''));
   // Recurring series belonging to the project — listed once per series via
@@ -198,15 +200,13 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
       setDragOverIdx(null);
       return;
     }
-    const incompleteUnscheduled = projectUnscheduled.filter(t => !t.completed);
-    const fromId = incompleteUnscheduled[dragIdx].id;
-    const toId = incompleteUnscheduled[idx].id;
-    const next = [...unscheduledTasks];
-    const fromFull = next.findIndex(t => t.id === fromId);
-    const toFull = next.findIndex(t => t.id === toId);
-    const [moved] = next.splice(fromFull, 1);
-    next.splice(toFull, 0, moved);
-    reorderUnscheduledTasks(next);
+    // The new order as a field on each task (utils/projectOrder.js): syncs
+    // on both tiers and survives the Obsidian cycle, which rebuilds the
+    // array. The array positions move too, as before.
+    const ordered = projectUnscheduled.filter(t => !t.completed).map(t => t.id);
+    const [moved] = ordered.splice(dragIdx, 1);
+    ordered.splice(idx, 0, moved);
+    reorderUnscheduledTasks(applyProjectReorder(unscheduledTasks, ordered));
     setDragIdx(null);
     setDragOverIdx(null);
   };
@@ -229,16 +229,11 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
     const { fromIdx, overIdx } = touchDragRef.current;
     touchDragRef.current = { active: false, fromIdx: null, overIdx: null };
     if (fromIdx !== null && overIdx !== null && fromIdx !== overIdx) {
-      const incompleteUnscheduled = projectUnscheduled.filter(t => !t.completed);
-      const fromId = incompleteUnscheduled[fromIdx]?.id;
-      const toId = incompleteUnscheduled[overIdx]?.id;
-      if (fromId && toId) {
-        const next = [...unscheduledTasks];
-        const fromFull = next.findIndex(t => t.id === fromId);
-        const toFull = next.findIndex(t => t.id === toId);
-        const [moved] = next.splice(fromFull, 1);
-        next.splice(toFull, 0, moved);
-        reorderUnscheduledTasks(next);
+      const ordered = projectUnscheduled.filter(t => !t.completed).map(t => t.id);
+      if (ordered[fromIdx] && ordered[overIdx]) {
+        const [moved] = ordered.splice(fromIdx, 1);
+        ordered.splice(overIdx, 0, moved);
+        reorderUnscheduledTasks(applyProjectReorder(unscheduledTasks, ordered));
       }
     }
     setDragIdx(null);

--- a/src/components/projects/ProjectPlanner.jsx
+++ b/src/components/projects/ProjectPlanner.jsx
@@ -19,6 +19,7 @@ const IS_IOS = typeof navigator !== 'undefined' && (
 import SchedTaskCard from '../sched/SchedTaskCard.jsx';
 import HyperGlanceEditor from './HyperGlanceEditor.jsx';
 import RecurringSeriesRow from './RecurringSeriesRow.jsx';
+import { sortByProjectOrder, applyProjectReorder } from '../../utils/projectOrder.js';
 
 /**
  * PLANNER — a per-project planning dashboard, themed to the project's color.
@@ -113,7 +114,8 @@ const ProjectPlanner = ({ project, onClose }) => {
     }
     const completedScheduled = scheduled.filter(task => task.completed);
     if (showCompleted && completedScheduled.length) byDay.push({ dateStr: null, tasks: completedScheduled });
-    let inbox = mine(unscheduledTasks).sort((a, b) => (a.completed ? 1 : 0) - (b.completed ? 1 : 0));
+    // projectOrder first (utils/projectOrder.js), then completed last; both sorts are stable.
+    let inbox = sortByProjectOrder(mine(unscheduledTasks)).sort((a, b) => (a.completed ? 1 : 0) - (b.completed ? 1 : 0));
     if (!showCompleted) inbox = inbox.filter(task => !task.completed);
     return { scheduledDays: byDay, unscheduled: inbox };
   }, [tasks, unscheduledTasks, project.id, isVisibleForUser, showCompleted]);
@@ -144,15 +146,13 @@ const ProjectPlanner = ({ project, onClose }) => {
   const incompleteUnscheduled = unscheduled.filter(task => !task.completed);
 
   const applyReorder = (fromIdx, toIdx) => {
-    const fromId = incompleteUnscheduled[fromIdx]?.id;
-    const toId = incompleteUnscheduled[toIdx]?.id;
-    if (!fromId || !toId) return;
-    const next = [...unscheduledTasks];
-    const fromFull = next.findIndex(task => task.id === fromId);
-    const toFull = next.findIndex(task => task.id === toId);
-    const [moved] = next.splice(fromFull, 1);
-    next.splice(toFull, 0, moved);
-    reorderUnscheduledTasks(next);
+    const ordered = incompleteUnscheduled.map(task => task.id);
+    if (!ordered[fromIdx] || !ordered[toIdx]) return;
+    const [moved] = ordered.splice(fromIdx, 1);
+    ordered.splice(toIdx, 0, moved);
+    // A field on each task (utils/projectOrder.js): syncs on both tiers and
+    // survives the Obsidian cycle. Array positions move too, as before.
+    reorderUnscheduledTasks(applyProjectReorder(unscheduledTasks, ordered));
   };
 
   const handleDragStart = (e, idx) => {

--- a/src/utils/mergeObsidianTasks.test.js
+++ b/src/utils/mergeObsidianTasks.test.js
@@ -38,6 +38,13 @@ describe('mergeObsidianTasks', () => {
     expect(out[0].completedAt).toBe('2026-06-01');
   });
 
+  it('carries projectOrder across a re-parse (the project card order is a task field, 2026-09-08)', () => {
+    const prev = [obs('a', { projectId: 'p1', projectOrder: 20 })];
+    const out = mergeObsidianTasks(prev, [obs('a')], new Set(['a']), preserveObsidianAppFields);
+    expect(out[0].projectOrder).toBe(20);
+    expect(out[0].projectId).toBe('p1');
+  });
+
   it('passes non-Obsidian tasks through untouched and never retains them', () => {
     const prev = [plain('p1'), obs('a'), plain('p2')];
     const out = mergeObsidianTasks(prev, [], new Set(), preserve);

--- a/src/utils/projectOrder.js
+++ b/src/utils/projectOrder.js
@@ -1,0 +1,59 @@
+// The order of a project's unscheduled tasks, as a field on each task.
+//
+// Until 2026-09-08 that order was nothing more than the tasks' positions in
+// the inbox array. It travelled on the file tier (a reorder timestamp picks
+// whose array wins) but the DB tier syncs one row per task and carries no
+// array order, so on GLANCEvault the order never left the device that set
+// it; and every Obsidian cycle rebuilds the inbox array (app tasks, then
+// vault tasks in scan order, then the rest), so a reorder lasted until the
+// next cycle. A field on the task rides the row on both tiers, resolves by
+// the task's own last-writer-wins, is compared by the stamp pass like any
+// other edit, and is carried across a re-parse like any other app field.
+//
+// Ruling (2026-09-08): the order is the app's. The project note keeps its
+// own line order and neither reads nor writes this field (buildout spec
+// 2.5 records the deferred design for making the note follow it).
+
+export const PROJECT_ORDER_STEP = 10;
+
+const hasOrder = (t) => typeof t?.projectOrder === 'number' && Number.isFinite(t.projectOrder);
+
+/**
+ * Stable sort: tasks carrying projectOrder first, ascending; tasks without
+ * one after, in their given order (a task newly added to the project lands
+ * at the end, as before).
+ */
+export function sortByProjectOrder(tasks) {
+  const list = Array.isArray(tasks) ? tasks : [];
+  const ordered = list.filter(hasOrder).map((t, i) => ({ t, i }))
+    .sort((a, b) => (a.t.projectOrder - b.t.projectOrder) || (a.i - b.i))
+    .map(({ t }) => t);
+  return [...ordered, ...list.filter((t) => !hasOrder(t))];
+}
+
+/**
+ * Apply a reorder of one project's tasks to the inbox array. `orderedIds` is
+ * the project's reorderable tasks in their new order. Each gets a renumbered
+ * projectOrder (0, 10, 20, ...) and a fresh stamp so the change syncs and
+ * wins the merge; the array positions move too, so the file tier and the
+ * general inbox see the same order they always did.
+ */
+export function applyProjectReorder(unscheduledTasks, orderedIds, now = new Date().toISOString()) {
+  const ids = (orderedIds || []).map(String);
+  const orderOf = new Map(ids.map((id, i) => [id, i * PROJECT_ORDER_STEP]));
+  const byId = new Map((unscheduledTasks || []).map((t) => [String(t.id), t]));
+  const restamped = (t) => {
+    const order = orderOf.get(String(t.id));
+    if (order === undefined) return t;
+    if (t.projectOrder === order) return t;                 // already there: no stamp, no push
+    return { ...t, projectOrder: order, lastModified: now };
+  };
+  // Array positions: the moved group occupies the slots its members held,
+  // in the new order; everything else stays where it was.
+  const slots = [];
+  (unscheduledTasks || []).forEach((t, i) => { if (orderOf.has(String(t.id))) slots.push(i); });
+  const out = (unscheduledTasks || []).map(restamped);
+  const members = ids.filter((id) => byId.has(id)).map((id) => restamped(byId.get(id)));
+  slots.forEach((slot, k) => { if (k < members.length) out[slot] = members[k]; });
+  return out;
+}

--- a/src/utils/projectOrder.test.js
+++ b/src/utils/projectOrder.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { sortByProjectOrder, applyProjectReorder } from './projectOrder.js';
+
+const t = (id, extra = {}) => ({ id, title: id, projectId: 'p1', lastModified: '2026-09-01T00:00:00.000Z', ...extra });
+
+describe('sortByProjectOrder', () => {
+  it('orders by the field, keeps unordered tasks after in array order, and is stable on ties', () => {
+    const list = [t('c'), t('a', { projectOrder: 10 }), t('d'), t('b', { projectOrder: 0 }), t('e', { projectOrder: 10 })];
+    expect(sortByProjectOrder(list).map((x) => x.id)).toEqual(['b', 'a', 'e', 'c', 'd']);
+  });
+
+  it('a list with no field at all keeps its order (the pre-field behavior)', () => {
+    expect(sortByProjectOrder([t('x'), t('y')]).map((x) => x.id)).toEqual(['x', 'y']);
+    expect(sortByProjectOrder(null)).toEqual([]);
+  });
+});
+
+describe('applyProjectReorder', () => {
+  const NOW = '2026-09-08T20:00:00.000Z';
+  const inbox = [t('other1', { projectId: 'p2' }), t('a'), t('b'), t('other2', { projectId: 'p2' }), t('c')];
+
+  it('renumbers the moved group, stamps the changed rows, and moves the array positions', () => {
+    const out = applyProjectReorder(inbox, ['c', 'a', 'b'], NOW);
+    expect(out.map((x) => x.id)).toEqual(['other1', 'c', 'a', 'other2', 'b']);   // the group's slots, new order
+    expect(out.find((x) => x.id === 'c')).toMatchObject({ projectOrder: 0, lastModified: NOW });
+    expect(out.find((x) => x.id === 'a')).toMatchObject({ projectOrder: 10, lastModified: NOW });
+    expect(out.find((x) => x.id === 'b')).toMatchObject({ projectOrder: 20, lastModified: NOW });
+    expect(out.find((x) => x.id === 'other1')).toBe(inbox[0]);                    // untouched rows are the same objects
+    expect(sortByProjectOrder(out.filter((x) => x.projectId === 'p1')).map((x) => x.id)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('a task already at its number is not re-stamped (no needless push)', () => {
+    const first = applyProjectReorder(inbox, ['a', 'b', 'c'], NOW);
+    const again = applyProjectReorder(first, ['a', 'b', 'c'], '2026-09-08T21:00:00.000Z');
+    expect(again.find((x) => x.id === 'a')).toBe(first.find((x) => x.id === 'a'));
+    expect(again.every((x) => x.lastModified !== '2026-09-08T21:00:00.000Z')).toBe(true);
+  });
+
+  it('ids not in the inbox are ignored; the rest still renumber', () => {
+    const out = applyProjectReorder(inbox, ['ghost', 'b', 'a', 'c'], NOW);
+    expect(out.find((x) => x.id === 'b').projectOrder).toBe(10);
+    expect(out.find((x) => x.id === 'a').projectOrder).toBe(20);
+    expect(out).toHaveLength(inbox.length);
+  });
+});


### PR DESCRIPTION
## Summary

Reordering a project's unscheduled tasks reverted on desktop and appeared not to work at all on Android.

**Why.** The order was nothing more than the tasks' positions in the inbox array. Two things broke that:

- The DB tier syncs one row per task and carries no array order, so on GLANCEvault a reorder never left the device that made it. Only the file tier (the iCloud and WebDAV file, chosen by a reorder timestamp) ever carried it.
- Every Obsidian cycle rebuilds the inbox array: app tasks first, then vault tasks in scan order, then the rest. So a reorder lasted until the next cycle, which under SSE is seconds. On Android, where cycles run continuously in holding posture, the snap-back was immediate enough to read as "cannot reorder". The row drag itself was fine, and is unchanged.

## Changes

- **`src/utils/projectOrder.js`**, pure and tested. `sortByProjectOrder`: tasks carrying the field first, ascending; tasks without one after, in array order, so a task newly added to a project still lands at the end. `applyProjectReorder`: renumbers the moved group 0, 10, 20 with a fresh stamp on the rows that changed (a row already at its number is not re-stamped, so nothing pushes needlessly), and moves the array positions as before so the file tier and the general inbox see what they always did.
- **Project card and planner** sort by the field and reorder through it, on the HTML5 drag path and the iOS grip path alike.
- **No new sync or merge code.** The field rides the task row on both tiers, resolves by the task's own last-writer-wins, is compared by the stamp pass like any other edit, and is carried across an Obsidian re-parse like any other app field. A test pins the carry.

**Scope, per your answers:** unscheduled project tasks only; scheduled tasks still sort by date and completed tasks still go last; a newly added task lands last; the general inbox order is untouched.

**Ruling recorded** in `docs/obsidian-buildout-spec.md` 2.5: the order is the app's; the linked project note keeps its own line order and neither reads nor writes the field. Making the note's Tasks section follow the app's order is written down as a deferred design with what it would take (a reorder intent, an amendment to the never-sorted ruling, and a decision on the reverse direction).

## Tests

`src/utils/projectOrder.test.js`: sort by field, stability, the no-field case; reorder renumbering, stamping, array positions, the no-op re-stamp, unknown ids. `mergeObsidianTasks.test.js`: the field survives a re-parse. Related suites 39/39, lint and whitespace clean.

## Field check after the rebuild

Reorder inside a project card on the Mac, then watch the same project on Android and Windows: the order should arrive within a sync cycle and stay put through Obsidian cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_