### PR TITLE
ICS: each recurring occurrence keeps its own duration; DURATION stands in for DTEND

### DIFF
--- a/src/utils/icsParser.js
+++ b/src/utils/icsParser.js
@@ -221,6 +221,12 @@ export const parseICS = (icsContent) => {
         currentEvent.dtend = dateStr;
         const tzid = extractTzid(line);
         if (tzid) currentEvent.dtendTzid = tzid;
+      } else if (line.startsWith('DURATION:')) {
+        // RFC 5545 allows DURATION in place of DTEND; some CalDAV servers
+        // emit it for recurring events. Kept as minutes and used wherever
+        // DTEND is absent (2026-09-08).
+        const mins = parseIcsDuration(line.substring(9));
+        if (mins !== null) currentEvent.durationMinutes = mins;
       } else if (line.startsWith('DUE')) {
         // Handle VTODO due dates
         if (line.includes('VALUE=DATE') || line.split(':')[1]?.length === 8) {
@@ -320,10 +326,25 @@ export const parseICS = (icsContent) => {
 
     // Duration in days for all-day events
     let durDays = 1;
+    if (!event.dtend && event.isAllDay && event.durationMinutes) {
+      durDays = Math.max(1, Math.round(event.durationMinutes / 1440));
+    }
     if (event.dtend && event.isAllDay) {
       const s = new Date(sYear, sMonth, sDay);
       const e = new Date(parseInt(event.dtend.substring(0, 4)), parseInt(event.dtend.substring(4, 6)) - 1, parseInt(event.dtend.substring(6, 8)));
       durDays = Math.max(1, Math.round((e - s) / 86400000));
+    }
+
+    // Timed series: each occurrence keeps the master's wall-clock END TIME
+    // and shifts the end DATE by the master's own start-to-end day span (0
+    // for a same-day event, 1 for one that crosses midnight). Copying the
+    // master's DTEND verbatim put every later occurrence's end before its
+    // start, so the negative duration fell back to 60 minutes (field report,
+    // 2026-09-08: every recurring CalDAV event showed an hour).
+    let endDayDelta = 0;
+    if (event.dtend && !event.isAllDay && event.dtend.length >= 8) {
+      const e = new Date(parseInt(event.dtend.substring(0, 4)), parseInt(event.dtend.substring(4, 6)) - 1, parseInt(event.dtend.substring(6, 8)));
+      endDayDelta = Math.round((e - new Date(sYear, sMonth, sDay)) / 86400000);
     }
 
     const eventStart = new Date(sYear, sMonth, sDay);
@@ -345,6 +366,10 @@ export const parseICS = (icsContent) => {
         const endD = new Date(occDate);
         endD.setDate(endD.getDate() + durDays);
         newDtend = fmt(endD);
+      } else if (event.dtend) {
+        const endD = new Date(occDate);
+        endD.setDate(endD.getDate() + endDayDelta);
+        newDtend = event.dtend.length > 8 ? fmt(endD) + event.dtend.substring(8) : fmt(endD);
       }
       expandedEvents.push({ ...event, dtstart: newDtstart, dtend: newDtend, rrule: undefined, isRecurringSeries: true });
     };
@@ -492,6 +517,18 @@ export const parseICS = (icsContent) => {
   return expandedEvents;
 };
 
+/**
+ * An RFC 5545 DURATION ("P1DT2H30M", "PT45M", "P2W") in minutes, or null when
+ * unreadable or negative. Seconds round to the nearest minute.
+ */
+export const parseIcsDuration = (spec) => {
+  const m = /^\+?P(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(String(spec || '').trim());
+  if (!m) return null;
+  const [, w, d, h, min, s] = m.map((x) => (x === undefined ? 0 : parseInt(x, 10)));
+  const total = w * 7 * 1440 + d * 1440 + h * 60 + min + Math.round(s / 60);
+  return total > 0 ? total : null;
+};
+
 export const parseDatetime = (dtstr, tzid = null) => {
   if (dtstr.length === 8) {
     return new Date(
@@ -553,7 +590,9 @@ export const filterByDateWindow = (importedTasks, retentionDays) => {
 export const expandMultiDayEvent = (event, options = {}) => {
   const { asTaskCalendar = false, freshCompletedUids = new Set(), color: customColor, importSource = 'sync', feedId } = options;
   const startDate = parseDatetime(event.dtstart, event.dtstartTzid);
-  const endDate = event.dtend ? parseDatetime(event.dtend, event.dtendTzid || event.dtstartTzid) : new Date(startDate.getTime() + 60 * 60 * 1000);
+  const endDate = event.dtend
+    ? parseDatetime(event.dtend, event.dtendTzid || event.dtstartTzid)
+    : new Date(startDate.getTime() + (event.durationMinutes || 60) * 60 * 1000);
   const duration = Math.round((endDate - startDate) / (1000 * 60));
 
   const isAllDay = event.isAllDay ||

--- a/src/utils/icsParser.test.js
+++ b/src/utils/icsParser.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseICS, parseDatetime, filterByDateWindow, expandMultiDayEvent } from './icsParser.js';
+import { parseICS, parseDatetime, filterByDateWindow, expandMultiDayEvent, parseIcsDuration } from './icsParser.js';
 import { dateToString } from './taskUtils.js';
 
 const wrap = (body) => `BEGIN:VCALENDAR\r\nVERSION:2.0\r\n${body}\r\nEND:VCALENDAR`;
@@ -128,6 +128,66 @@ describe('parseICS', () => {
     expect(events.masterUids.has('plain')).toBe(true);
     // masterUids must not appear during iteration/serialization
     expect(Object.keys(events)).not.toContain('masterUids');
+  });
+});
+
+describe('recurring event duration (field report, 2026-09-08)', () => {
+  const durations = (ics) => parseICS(ics).map(e => expandMultiDayEvent(e)[0]).map(t => ({ date: t.date, startTime: t.startTime, duration: t.duration }));
+
+  it('every occurrence of a timed series keeps the series duration, not just the first', () => {
+    const out = durations(wrap(vevent([
+      'UID:weekly-30',
+      'SUMMARY:Check-in',
+      'DTSTART:20260706T093000',
+      'DTEND:20260706T100000',
+      'RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=3',
+    ])));
+    expect(out.map(o => o.duration)).toEqual([30, 30, 30]);
+    expect(out.map(o => o.startTime)).toEqual(['09:30', '09:30', '09:30']);
+  });
+
+  it('a series that crosses midnight ends on the next day for every occurrence', () => {
+    const events = parseICS(wrap(vevent([
+      'UID:overnight',
+      'SUMMARY:Night shift',
+      'DTSTART:20260706T220000',
+      'DTEND:20260707T010000',
+      'RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=2',
+    ])));
+    expect(events.map(e => e.dtend)).toEqual(['20260707T010000', '20260714T010000']);
+    expect(events.map(e => expandMultiDayEvent(e)[0].duration)).toEqual([180, 180]);
+  });
+
+  it('a UTC-stamped series keeps the Z on each occurrence end', () => {
+    const events = parseICS(wrap(vevent([
+      'UID:utc-weekly',
+      'SUMMARY:Sync',
+      'DTSTART:20260706T140000Z',
+      'DTEND:20260706T141500Z',
+      'RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=2',
+    ])));
+    expect(events[1].dtend).toBe('20260713T141500Z');
+    expect(events.map(e => expandMultiDayEvent(e)[0].duration)).toEqual([15, 15]);
+  });
+
+  it('DURATION stands in for a missing DTEND, on a single event and on every occurrence of a series', () => {
+    const single = durations(wrap(vevent(['UID:d1', 'SUMMARY:Quick', 'DTSTART:20260706T093000', 'DURATION:PT45M'])));
+    expect(single[0].duration).toBe(45);
+    const series = durations(wrap(vevent([
+      'UID:d2', 'SUMMARY:Series', 'DTSTART:20260706T093000', 'DURATION:PT1H30M', 'RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=3',
+    ])));
+    expect(series.map(o => o.duration)).toEqual([90, 90, 90]);
+  });
+
+  it('parseIcsDuration reads the RFC 5545 forms and rejects the rest', () => {
+    expect(parseIcsDuration('PT30M')).toBe(30);
+    expect(parseIcsDuration('PT1H30M')).toBe(90);
+    expect(parseIcsDuration('P1DT2H')).toBe(1560);
+    expect(parseIcsDuration('P2W')).toBe(20160);
+    expect(parseIcsDuration('PT90S')).toBe(2);
+    expect(parseIcsDuration('-PT15M')).toBeNull();
+    expect(parseIcsDuration('PT0M')).toBeNull();
+    expect(parseIcsDuration('soon')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Imported CalDAV recurring events showed 60 minutes regardless of their real length. Native calendar events were fine, since they do not pass through the ICS parser.

**Cause.** Expanding a timed RRULE series gave each occurrence its own start (occurrence date plus the master's start time) but the master's DTEND verbatim, which sits on the master's date. For every occurrence after the first the end came before the start, the duration went negative, and the expander's fallback replaced any non-positive duration with 60 minutes. Only the first occurrence, on the master's own date, was ever right.

A second, smaller path led to the same number: the parser never read DURATION, the RFC 5545 alternative to DTEND that some CalDAV servers emit for recurring events, so those events also fell back to 60 minutes.

## Changes, `src/utils/icsParser.js`

- Each occurrence's end keeps the master's wall-clock end time and shifts its end date by the master's own start-to-end day span. A same-day series shifts by zero; a series that crosses midnight ends on the next day for every occurrence; a UTC-stamped series keeps its Z on every occurrence end.
- DURATION is parsed (weeks, days, hours, minutes, seconds; negative or zero rejected) and used wherever DTEND is absent: single events, every occurrence of a series, and the all-day day count. `parseIcsDuration` is exported.
- Nothing else about expansion changes: EXDATE, RECURRENCE-ID overrides, TZIDs and all-day handling are untouched, and the existing 60-minute fallback still applies when a feed gives neither DTEND nor DURATION.

## Tests

`src/utils/icsParser.test.js`: a 30-minute weekly series gives 30 on every occurrence; a series crossing midnight ends the next day each time with 180 minutes; a UTC series keeps its Z; DURATION on a single event and on a series; the duration grammar. The parser, native-calendar, and every calendar-named suite pass, 148 tests. Lint and whitespace clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_