### PR TITLE
Whole-row long-press reorder on Android and other non-iOS touch devices

### DIFF
--- a/src/components/BucketListModal.jsx
+++ b/src/components/BucketListModal.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../context/FeaturesContext.jsx';
 import { BUCKET_LIST_IDS, promoteToInbox } from '../utils/bucketList.js';
+import { beginLongPressReorder, isLongPressRowDevice } from '../utils/longPressReorder.js';
 import { renderFormattedText, renderTitleWithoutTags, hasNotesOrSubtasks, hasOnlySubtasks } from '../utils/textFormatting.jsx';
 
 // Same iOS detection as ProjectPlanner/ProjectCard: grip-only touch drag on
@@ -13,6 +14,12 @@ const IS_IOS = typeof navigator !== 'undefined' && (
   (/Mac/.test(navigator.platform || '') && (navigator.maxTouchPoints || 0) > 1) ||
   (typeof window !== 'undefined' && !!window.DayGlanceIOS)
 );
+
+// Android and other non-iOS touch devices: the row itself carries a
+// long-press touch reorder (utils/longPressReorder.js) and is not an HTML5
+// draggable, so hold-anywhere-on-the-row no longer depends on the WebView
+// starting a drag from a long press.
+const IS_LONG_PRESS_ROW = isLongPressRowDevice();
 
 /**
  * Bucket List — the someday/maybe space. A PLANNER without a project: same
@@ -221,6 +228,29 @@ const BucketListModal = () => {
     document.addEventListener('dragstart', preventDrag);
   };
 
+  // Whole-row long-press reorder on non-iOS touch devices, scoped to one
+  // list (utils/longPressReorder.js owns the hold and the listeners).
+  const handleRowTouchStart = (e, listId, idx) => {
+    beginLongPressReorder(e, {
+      idx,
+      hitSelector: `[data-bucket-drag="${listId}"]`,
+      onActivate: (fromIdx) => {
+        touchDragRef.current = { active: true, listId, fromIdx, overIdx: null };
+        setDrag({ listId, idx: fromIdx, overIdx: null });
+      },
+      onOver: (overIdx) => {
+        touchDragRef.current.overIdx = overIdx;
+        setDrag(prev => ({ ...prev, overIdx }));
+      },
+      onEnd: ({ activated, fromIdx, overIdx }) => {
+        if (!activated) return;
+        touchDragRef.current = { active: false, listId: null, fromIdx: null, overIdx: null };
+        if (fromIdx !== null && overIdx !== null && fromIdx !== overIdx) applyReorder(listId, fromIdx, overIdx);
+        setDrag({ listId: null, idx: null, overIdx: null });
+      },
+    });
+  };
+
   // ── Render helpers ────────────────────────────────────────────────────────
 
   const renderRow = (task, listId, idx, draggable) => {
@@ -230,11 +260,12 @@ const BucketListModal = () => {
         key={task.id}
         data-bucket-drag={draggable ? listId : undefined}
         data-drag-idx={draggable ? idx : undefined}
-        draggable={draggable && !IS_IOS}
-        onDragStart={draggable && !IS_IOS ? (e) => { setDrag({ listId, idx, overIdx: null }); e.dataTransfer.effectAllowed = 'move'; } : undefined}
+        draggable={draggable && !IS_IOS && !IS_LONG_PRESS_ROW}
+        onDragStart={draggable && !IS_IOS && !IS_LONG_PRESS_ROW ? (e) => { setDrag({ listId, idx, overIdx: null }); e.dataTransfer.effectAllowed = 'move'; } : undefined}
         onDragOver={draggable ? (e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; if (drag.listId === listId && idx !== drag.overIdx) setDrag(prev => ({ ...prev, overIdx: idx })); } : undefined}
         onDrop={draggable ? (e) => handleDrop(e, listId, idx) : undefined}
         onDragEnd={draggable ? () => setDrag({ listId: null, idx: null, overIdx: null }) : undefined}
+        onTouchStart={draggable && IS_LONG_PRESS_ROW ? (e) => handleRowTouchStart(e, listId, idx) : undefined}
         className={`group flex items-center gap-2 px-2 py-2 rounded-lg border ${borderClass} ${darkMode ? 'bg-gray-700/40' : 'bg-stone-50'} ${isDragOver ? 'ring-2 ring-sky-400' : ''}`}
       >
         {draggable && (

--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -22,6 +22,7 @@ import { getNextOccurrence } from '../../utils/recurrenceEngine.js';
 import { getActiveHGInstance } from '../../hooks/useHyperGlance.js';
 import { noteLinkOf } from '../../utils/obsidianProjectNotes.js';
 import { sortByProjectOrder, applyProjectReorder } from '../../utils/projectOrder.js';
+import { beginLongPressReorder, isLongPressRowDevice } from '../../utils/longPressReorder.js';
 import { formatLocalizedDate } from '../../utils/localeFormatting.js';
 
 const toHex = (bgClass) => TAILWIND_TO_HEX[bgClass] || '#3b82f6';
@@ -39,6 +40,12 @@ const IS_IOS = typeof navigator !== 'undefined' && (
   (/Mac/.test(navigator.platform || '') && (navigator.maxTouchPoints || 0) > 1) ||
   (typeof window !== 'undefined' && !!window.DayGlanceIOS)
 );
+
+// Android and other non-iOS touch devices: the row itself carries a
+// long-press touch reorder (utils/longPressReorder.js) and is not an HTML5
+// draggable, so hold-anywhere-on-the-row no longer depends on the WebView
+// starting a drag from a long press.
+const IS_LONG_PRESS_ROW = isLongPressRowDevice();
 
 /**
  * ProjectCard — a single project node in the Goals dashboard.
@@ -272,6 +279,24 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
     document.addEventListener('touchend', onEnd);
     document.addEventListener('touchcancel', onEnd);
     document.addEventListener('dragstart', preventDrag);
+  };
+
+  // Whole-row long-press reorder on non-iOS touch devices. Same refs and
+  // finish as the grip path; the helper owns the hold, the document
+  // listeners and the scroll-versus-hold decision.
+  const handleRowTouchStart = (e, idx) => {
+    beginLongPressReorder(e, {
+      idx,
+      onActivate: (fromIdx) => {
+        touchDragRef.current = { active: true, fromIdx, overIdx: null };
+        setDragIdx(fromIdx);
+      },
+      onOver: (overIdx) => {
+        touchDragRef.current.overIdx = overIdx;
+        setDragOverIdx(overIdx);
+      },
+      onEnd: ({ activated }) => { if (activated) finishGripTouch(); },
+    });
   };
 
   // ── Quick-add ──────────────────────────────────────────────────────────────
@@ -535,7 +560,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
               const draggable = incompleteUnscheduledIdx !== -1;
               // Whole-row HTML5 drag off-iOS (Android/desktop — grab anywhere on
               // the row); grip-only touch drag on iOS (see IS_IOS note above).
-              const rowDraggable = draggable && !IS_IOS;
+              const rowDraggable = draggable && !IS_IOS && !IS_LONG_PRESS_ROW;
               return (
                 <div
                   key={task.id}
@@ -545,6 +570,7 @@ const ProjectCard = forwardRef(({ project, onEditClick, compact, dragHandleProps
                   onDragEnd={rowDraggable ? handleDragEnd : undefined}
                   onDragOver={draggable ? e => handleDragOver(e, incompleteUnscheduledIdx) : undefined}
                   onDrop={draggable ? e => handleDrop(e, incompleteUnscheduledIdx) : undefined}
+                  onTouchStart={draggable && IS_LONG_PRESS_ROW ? e => handleRowTouchStart(e, incompleteUnscheduledIdx) : undefined}
                   className={`flex items-center rounded-lg select-none dnd-no-select transition-colors ${hoverBg} ${
                     draggable && dragIdx === incompleteUnscheduledIdx ? 'opacity-40' : ''
                   } ${

--- a/src/components/projects/ProjectPlanner.jsx
+++ b/src/components/projects/ProjectPlanner.jsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { dateToString } from '../../utils/taskUtils.js';
 import { getNextOccurrence } from '../../utils/recurrenceEngine.js';
 import { getProjectColor, taskColorToHex, hexToRgba } from '../../utils/colorUtils.js';
+import { beginLongPressReorder, isLongPressRowDevice } from '../../utils/longPressReorder.js';
 import { plannerColumns } from '../../utils/plannerColumns.js';
 import { renderFormattedText } from '../../utils/textFormatting.jsx';
 
@@ -16,6 +17,12 @@ const IS_IOS = typeof navigator !== 'undefined' && (
   (/Mac/.test(navigator.platform || '') && (navigator.maxTouchPoints || 0) > 1) ||
   (typeof window !== 'undefined' && !!window.DayGlanceIOS)
 );
+
+// Android and other non-iOS touch devices: the row itself carries a
+// long-press touch reorder (utils/longPressReorder.js) and is not an HTML5
+// draggable, so hold-anywhere-on-the-row no longer depends on the WebView
+// starting a drag from a long press.
+const IS_LONG_PRESS_ROW = isLongPressRowDevice();
 import SchedTaskCard from '../sched/SchedTaskCard.jsx';
 import HyperGlanceEditor from './HyperGlanceEditor.jsx';
 import RecurringSeriesRow from './RecurringSeriesRow.jsx';
@@ -218,6 +225,29 @@ const ProjectPlanner = ({ project, onClose }) => {
     document.addEventListener('touchend', onEnd);
     document.addEventListener('touchcancel', onEnd);
     document.addEventListener('dragstart', preventDrag);
+  };
+
+  // Whole-row long-press reorder on non-iOS touch devices (the card's
+  // pattern; utils/longPressReorder.js owns the hold and the listeners).
+  const handleRowTouchStart = (e, idx) => {
+    beginLongPressReorder(e, {
+      idx,
+      onActivate: (fromIdx) => {
+        touchDragRef.current = { active: true, fromIdx, overIdx: null };
+        setDragIdx(fromIdx);
+      },
+      onOver: (overIdx) => {
+        touchDragRef.current.overIdx = overIdx;
+        setDragOverIdx(overIdx);
+      },
+      onEnd: ({ activated, fromIdx, overIdx }) => {
+        if (!activated) return;
+        touchDragRef.current = { active: false, fromIdx: null, overIdx: null };
+        if (fromIdx !== null && overIdx !== null && fromIdx !== overIdx) applyReorder(fromIdx, overIdx);
+        setDragIdx(null);
+        setDragOverIdx(null);
+      },
+    });
   };
 
   // Quick-add an unscheduled project task — same inheritance as the card
@@ -425,7 +455,7 @@ const ProjectPlanner = ({ project, onClose }) => {
                       onSchedule={task.completed ? null : (t) => scheduleTaskAtNextSlot(t.id, true)}
                       dnd={draggable ? {
                         idx,
-                        rowDraggable: !IS_IOS,
+                        rowDraggable: !IS_IOS && !IS_LONG_PRESS_ROW,
                         onDragStart: handleDragStart,
                         onDragEnd: handleDragEnd,
                         onDragOver: handleDragOver,
@@ -433,6 +463,7 @@ const ProjectPlanner = ({ project, onClose }) => {
                         isSource: dragIdx === idx,
                         isTarget: dragOverIdx === idx && dragIdx !== idx,
                         onGripTouchStart: IS_IOS ? handleGripTouchStart : null,
+                        onRowTouchStart: IS_LONG_PRESS_ROW ? handleRowTouchStart : null,
                       } : null}
                     />
                   );

--- a/src/components/sched/SchedTaskCard.jsx
+++ b/src/components/sched/SchedTaskCard.jsx
@@ -120,6 +120,7 @@ const SchedTaskCard = ({ task, isInbox = false, showProject = false, onEdit = nu
       onDragEnd={dnd?.rowDraggable ? dnd.onDragEnd : undefined}
       onDragOver={dnd ? e => dnd.onDragOver(e, dnd.idx) : undefined}
       onDrop={dnd ? e => dnd.onDrop(e, dnd.idx) : undefined}
+      onTouchStart={dnd?.onRowTouchStart ? e => dnd.onRowTouchStart(e, dnd.idx) : undefined}
       className={`flex items-center gap-2 rounded-xl border ${borderClass} ${cardBg} px-3 py-2 ${
         isEvent ? '' : 'cursor-pointer active:opacity-70'
       } ${task.completed || isFinishedEvent ? 'opacity-55' : ''} ${dnd ? 'select-none dnd-no-select' : ''} ${

--- a/src/utils/longPressReorder.js
+++ b/src/utils/longPressReorder.js
@@ -1,0 +1,153 @@
+// Whole-row long-press reorder for touch devices.
+//
+// Task rows in the project card, the project planner and the bucket list are
+// reordered by HTML5 drag on desktop. On Android the same rows relied on the
+// WebView starting an HTML5 drag from a long press, which the app never
+// controlled: it worked for months and then stopped with a WebView update
+// (151.0.7922.199 was the first version seen failing). The row now owns the
+// gesture itself, the way the inbox and the timeline already do: hold
+// anywhere on the row for LONG_PRESS_MS, then move to reorder; a finger that
+// moves before the hold completes is a scroll and is left alone.
+//
+// iOS keeps its existing grip-only path (ProjectCard's IS_IOS note). This
+// module only adds the row gesture on the other touch devices.
+import { isNativeAndroid, triggerHaptic } from '../native.js';
+
+export const LONG_PRESS_MS = 500;
+export const LONG_PRESS_CANCEL_PX = 10;
+
+/**
+ * iOS/iPadOS, including the native shell and an iPad reporting as a Mac.
+ * Mirrors the IS_IOS check the three reorder surfaces already carry.
+ */
+export const isIOSTouchDevice = () => typeof navigator !== 'undefined' && (
+  /iP(hone|ad|od)/.test(navigator.platform || '') ||
+  (/Mac/.test(navigator.platform || '') && (navigator.maxTouchPoints || 0) > 1) ||
+  (typeof window !== 'undefined' && !!window.DayGlanceIOS)
+);
+
+/**
+ * True where a task row should carry the long-press touch reorder instead of
+ * an HTML5 draggable: the Android shell, or any browser whose primary pointer
+ * is a touch screen, except iOS (which keeps its grip path).
+ */
+export const isLongPressRowDevice = () => {
+  if (isIOSTouchDevice()) return false;
+  if (isNativeAndroid()) return true;
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  try {
+    return !!window.matchMedia('(pointer: coarse)').matches;
+  } catch (_) {
+    return false;
+  }
+};
+
+/**
+ * Start a long-press reorder from a row's touchstart.
+ *
+ * Listeners go on the document (non-passive, so preventDefault is honoured)
+ * and are removed when the touch ends, exactly like the grip path. Until the
+ * hold completes nothing is prevented, so a tap still clicks and a swipe
+ * still scrolls. Once it completes the finger owns the gesture: moves are
+ * prevented and hit-tested against `hitSelector`, the browser's own drag,
+ * context menu and the click synthesized on release are all suppressed.
+ *
+ * @param {TouchEvent} e            the row's touchstart
+ * @param {object} opts
+ * @param {number} opts.idx         the row's reorder index
+ * @param {string} [opts.hitSelector='[data-drag-idx]'] rows to hit-test
+ * @param {(idx:number)=>void} [opts.onActivate]  hold completed
+ * @param {(overIdx:number)=>void} [opts.onOver]  finger over another row
+ * @param {(r:{activated:boolean, fromIdx:number, overIdx:number|null})=>void} [opts.onEnd]
+ * @param {number} [opts.longPressMs]
+ * @param {number} [opts.cancelPx]
+ * @param {Document} [opts.doc]     injectable for tests
+ * @param {Function} [opts.setTimeoutFn]
+ * @param {Function} [opts.clearTimeoutFn]
+ * @param {Function} [opts.haptic]
+ * @returns {() => void} cancel: tears the gesture down without an onEnd
+ */
+export function beginLongPressReorder(e, {
+  idx,
+  hitSelector = '[data-drag-idx]',
+  onActivate,
+  onOver,
+  onEnd,
+  longPressMs = LONG_PRESS_MS,
+  cancelPx = LONG_PRESS_CANCEL_PX,
+  doc = typeof document !== 'undefined' ? document : null,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  haptic = triggerHaptic,
+} = {}) {
+  const touch = e?.touches?.[0];
+  if (!doc || !touch || (e.touches && e.touches.length > 1)) return () => {};
+
+  const start = { x: touch.clientX, y: touch.clientY };
+  const state = { activated: false, fromIdx: idx, overIdx: null };
+  let timer = null;
+
+  const preventDefault = (ev) => ev.preventDefault();
+
+  const teardown = () => {
+    if (timer !== null) {
+      clearTimeoutFn(timer);
+      timer = null;
+    }
+    doc.removeEventListener('touchmove', onMove);
+    doc.removeEventListener('touchend', onTouchEnd);
+    doc.removeEventListener('touchcancel', onTouchCancel);
+    doc.removeEventListener('dragstart', preventDefault);
+    doc.removeEventListener('contextmenu', preventDefault);
+  };
+
+  const activate = () => {
+    timer = null;
+    state.activated = true;
+    try { doc.defaultView?.getSelection?.()?.removeAllRanges?.(); } catch (_) {}
+    try { haptic('heavy'); } catch (_) {}
+    onActivate?.(idx);
+  };
+
+  const onMove = (moveEvent) => {
+    const t = moveEvent.touches?.[0];
+    if (!t) return;
+    if (!state.activated) {
+      const dx = t.clientX - start.x;
+      const dy = t.clientY - start.y;
+      if (Math.sqrt(dx * dx + dy * dy) > cancelPx) teardown(); // a scroll, not a hold
+      return;
+    }
+    moveEvent.preventDefault(); // honoured: registered non-passive
+    const el = typeof doc.elementFromPoint === 'function'
+      ? doc.elementFromPoint(t.clientX, t.clientY)
+      : null;
+    const rowEl = el?.closest?.(hitSelector);
+    if (!rowEl) return;
+    const overIdx = parseInt(rowEl.getAttribute('data-drag-idx'), 10);
+    if (Number.isNaN(overIdx) || overIdx === state.overIdx) return;
+    state.overIdx = overIdx;
+    onOver?.(overIdx);
+  };
+
+  const finish = (endEvent) => {
+    const wasActive = state.activated;
+    if (wasActive && endEvent?.cancelable) endEvent.preventDefault(); // no synthesized click
+    teardown();
+    onEnd?.({ activated: wasActive, fromIdx: state.fromIdx, overIdx: state.overIdx });
+  };
+  const onTouchEnd = (endEvent) => finish(endEvent);
+  const onTouchCancel = () => {
+    state.overIdx = null;
+    finish(null);
+  };
+
+  doc.addEventListener('touchmove', onMove, { passive: false });
+  doc.addEventListener('touchend', onTouchEnd);
+  doc.addEventListener('touchcancel', onTouchCancel);
+  doc.addEventListener('dragstart', preventDefault);
+  doc.addEventListener('contextmenu', preventDefault);
+  timer = setTimeoutFn(activate, longPressMs);
+
+  return teardown;
+}

--- a/src/utils/longPressReorder.test.js
+++ b/src/utils/longPressReorder.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from 'vitest';
+import { beginLongPressReorder, LONG_PRESS_MS, LONG_PRESS_CANCEL_PX } from './longPressReorder.js';
+
+// A document stand-in: listeners by type, an elementFromPoint the test
+// controls, and a counter so listener leaks show up.
+function fakeDoc() {
+  const listeners = new Map();
+  const doc = {
+    hit: null,
+    addEventListener(type, fn) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type).add(fn);
+    },
+    removeEventListener(type, fn) {
+      listeners.get(type)?.delete(fn);
+    },
+    dispatch(type, ev = {}) {
+      const e = { cancelable: true, preventDefault: vi.fn(), ...ev };
+      for (const fn of [...(listeners.get(type) || [])]) fn(e);
+      return e;
+    },
+    elementFromPoint: () => doc.hit,
+    listenerCount: () => [...listeners.values()].reduce((n, s) => n + s.size, 0),
+  };
+  return doc;
+}
+
+const row = (idx) => ({
+  closest: (sel) => (sel === '[data-drag-idx]' ? row.el(idx) : null),
+});
+row.el = (idx) => ({ getAttribute: () => String(idx) });
+
+const touchAt = (x, y) => ({ touches: [{ clientX: x, clientY: y }] });
+
+function start(doc, idx, cbs = {}, extra = {}) {
+  const timers = [];
+  const setTimeoutFn = (fn, ms) => { timers.push({ fn, ms }); return timers.length; };
+  const clearTimeoutFn = (id) => { timers[id - 1].cleared = true; };
+  const haptic = vi.fn();
+  const cancel = beginLongPressReorder(touchAt(10, 10), {
+    idx, doc, setTimeoutFn, clearTimeoutFn, haptic, ...cbs, ...extra,
+  });
+  const fire = () => { const t = timers[0]; if (t && !t.cleared) t.fn(); };
+  return { timers, fire, haptic, cancel };
+}
+
+describe('beginLongPressReorder', () => {
+  it('holds for LONG_PRESS_MS, then owns the gesture: moves prevented, rows hit-tested, click suppressed', () => {
+    const doc = fakeDoc();
+    const onActivate = vi.fn(); const onOver = vi.fn(); const onEnd = vi.fn();
+    const { timers, fire, haptic } = start(doc, 2, { onActivate, onOver, onEnd });
+    expect(timers[0].ms).toBe(LONG_PRESS_MS);
+
+    // Before the hold completes nothing is prevented (a swipe scrolls).
+    const early = doc.dispatch('touchmove', touchAt(12, 12));
+    expect(early.preventDefault).not.toHaveBeenCalled();
+
+    fire();
+    expect(onActivate).toHaveBeenCalledWith(2);
+    expect(haptic).toHaveBeenCalledWith('heavy');
+
+    doc.hit = row(0);
+    const mv = doc.dispatch('touchmove', touchAt(12, -40));
+    expect(mv.preventDefault).toHaveBeenCalled();
+    expect(onOver).toHaveBeenCalledWith(0);
+    // Same row again is not re-reported.
+    doc.dispatch('touchmove', touchAt(12, -42));
+    expect(onOver).toHaveBeenCalledTimes(1);
+
+    const end = doc.dispatch('touchend');
+    expect(end.preventDefault).toHaveBeenCalled();
+    expect(onEnd).toHaveBeenCalledWith({ activated: true, fromIdx: 2, overIdx: 0 });
+    expect(doc.listenerCount()).toBe(0);
+  });
+
+  it('a finger that moves past the cancel radius before the hold is a scroll: timer cleared, no callbacks, listeners gone', () => {
+    const doc = fakeDoc();
+    const onActivate = vi.fn(); const onEnd = vi.fn();
+    const { timers, fire } = start(doc, 1, { onActivate, onEnd });
+    doc.dispatch('touchmove', touchAt(10, 10 + LONG_PRESS_CANCEL_PX + 1));
+    expect(timers[0].cleared).toBe(true);
+    fire();
+    expect(onActivate).not.toHaveBeenCalled();
+    expect(onEnd).not.toHaveBeenCalled();
+    expect(doc.listenerCount()).toBe(0);
+  });
+
+  it('a tap (release before the hold) reports activated:false and does not prevent the click', () => {
+    const doc = fakeDoc();
+    const onEnd = vi.fn();
+    start(doc, 1, { onEnd });
+    const end = doc.dispatch('touchend');
+    expect(end.preventDefault).not.toHaveBeenCalled();
+    expect(onEnd).toHaveBeenCalledWith({ activated: false, fromIdx: 1, overIdx: null });
+    expect(doc.listenerCount()).toBe(0);
+  });
+
+  it('suppresses the browser drag and context menu for the duration of the gesture', () => {
+    const doc = fakeDoc();
+    start(doc, 0);
+    expect(doc.dispatch('dragstart').preventDefault).toHaveBeenCalled();
+    expect(doc.dispatch('contextmenu').preventDefault).toHaveBeenCalled();
+    doc.dispatch('touchend');
+    expect(doc.dispatch('dragstart').preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('touchcancel after activation ends with no target so the caller resets its highlight', () => {
+    const doc = fakeDoc();
+    const onEnd = vi.fn();
+    const { fire } = start(doc, 3, { onEnd });
+    fire();
+    doc.hit = row(1);
+    doc.dispatch('touchmove', touchAt(10, 60));
+    doc.dispatch('touchcancel');
+    expect(onEnd).toHaveBeenCalledWith({ activated: true, fromIdx: 3, overIdx: null });
+    expect(doc.listenerCount()).toBe(0);
+  });
+
+  it('ignores multi-touch starts and returns a no-op cancel', () => {
+    const doc = fakeDoc();
+    const cancel = beginLongPressReorder(
+      { touches: [{ clientX: 0, clientY: 0 }, { clientX: 5, clientY: 5 }] },
+      { idx: 0, doc },
+    );
+    expect(doc.listenerCount()).toBe(0);
+    expect(() => cancel()).not.toThrow();
+  });
+
+  it('the returned cancel tears down without an onEnd', () => {
+    const doc = fakeDoc();
+    const onEnd = vi.fn();
+    const { cancel } = start(doc, 0, { onEnd });
+    cancel();
+    expect(doc.listenerCount()).toBe(0);
+    expect(onEnd).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Task rows in the project card, the project planner and the bucket list were HTML5 draggables on Android and relied on the WebView starting a drag from a long press. That worked for months and stopped with a WebView update (151.0.7922.199 first seen failing): the hold highlighted the row and the move scrolled. Nothing in the app's drag code had changed since June, and project cards still drag because they use the app's own touch path from their grip.

The row now owns the gesture, the way the inbox and timeline already do. Hold anywhere on the row for half a second, then move to reorder. A finger that moves before the hold completes is a scroll and is left alone.

## Changes

- `src/utils/longPressReorder.js`: `beginLongPressReorder(e, opts)` runs the hold, the document-level non-passive listeners, the row hit-test, and suppresses the browser's own drag, the context menu and the click synthesized on release once the hold has completed. `isLongPressRowDevice()` is the Android shell or a coarse primary pointer, excluding iOS. Injectable document and timers so it tests under plain Node.
- `ProjectCard.jsx`, `ProjectPlanner.jsx` (through a new `onRowTouchStart` in `SchedTaskCard`'s `dnd` prop), `BucketListModal.jsx`: on long-press-row devices the row carries `onTouchStart` and is no longer an HTML5 draggable, so the two paths cannot compete. Same refs, highlights and reorder calls as the existing grip path.
- iOS keeps its grip-only path unchanged. Desktop keeps the whole-row mouse drag unchanged.

## Verification

- `src/utils/longPressReorder.test.js`: hold then reorder, scroll cancels before the hold, tap does not prevent the click, drag and context menu suppressed for the gesture, touchcancel resets, multi-touch ignored, cancel tears down without a callback.
- Full suite green, lint clean.
- Needs an Android build to confirm on the device: hold anywhere on a project task row, feel the haptic, move to another row, release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_