### PR TITLE
Launch on a new day rolls the routine-removal receipts instead of wiping them

### DIFF
--- a/src/hooks/useDataPersistence.js
+++ b/src/hooks/useDataPersistence.js
@@ -1,6 +1,7 @@
 import { dateToString } from '../utils/taskUtils.js';
 import { hasNativeCalendar } from '../utils/nativeCalendar.js';
 import { stampTimestamps } from '../utils/stampTimestamps.js';
+import { rolloverRemovedTodayRoutineIds, startOfTodayIso } from './useRoutines.js';
 
 // Read-only CalDAV/ICS-subscription events (importSource 'sync', non-task,
 // non-file) are ephemeral remote data, re-fetched live each session. On devices
@@ -140,11 +141,25 @@ export default function useDataPersistence({
         const removedData = localStorage.getItem('day-planner-removed-today-routine-ids');
         if (removedData) setRemovedTodayRoutineIds(JSON.parse(removedData));
       } else {
-        // Auto-clear if different day
+        // A new day since the last save: clear the chips, but KEEP the removal
+        // receipts and stamp one at local midnight for each cleared chip,
+        // exactly as the open-across-midnight rollover does (useRoutines.js).
+        // Wiping the map here pushed an empty bundle that the vault's grow-only
+        // merge undid on the next pull: one pointless write per launch, and
+        // two code paths disagreeing about the same day boundary.
+        let storedRemoved = {};
+        let storedChips = [];
+        try {
+          storedRemoved = JSON.parse(localStorage.getItem('day-planner-removed-today-routine-ids') || '{}') || {};
+        } catch (_) { storedRemoved = {}; }
+        try {
+          storedChips = JSON.parse(todayRoutinesData || '[]') || [];
+        } catch (_) { storedChips = []; }
+        const rolled = rolloverRemovedTodayRoutineIds(storedRemoved, storedChips, startOfTodayIso());
         setTodayRoutines([]);
         setRoutinesDate(todayStr);
-        setRemovedTodayRoutineIds({});
-        if (!isTrayMode) localStorage.removeItem('day-planner-removed-today-routine-ids');
+        setRemovedTodayRoutineIds(rolled);
+        if (!isTrayMode) localStorage.setItem('day-planner-removed-today-routine-ids', JSON.stringify(rolled));
       }
 
       // Load habit tracking data

--- a/src/hooks/useDataPersistence.test.js
+++ b/src/hooks/useDataPersistence.test.js
@@ -99,7 +99,36 @@ describe('loadData normalization write-back', () => {
       .toMatchObject({ id: 'u1', notes: '', subtasks: [] });
     expect(JSON.parse(written['day-planner-habits'])[0])
       .toMatchObject({ id: 'h1', scheduledDays: [0, 1, 2, 3, 4, 5, 6] });
-    expect(removeItem).toHaveBeenCalledWith('day-planner-removed-today-routine-ids');
+    // The removal receipts are rolled, not wiped: with nothing stored, the
+    // rolled map is empty and is persisted as such (never removeItem).
+    expect(removeItem).not.toHaveBeenCalled();
+    expect(written['day-planner-removed-today-routine-ids']).toBe('{}');
+  });
+
+  it('on a new day keeps the removal receipts and stamps one at midnight per cleared chip', async () => {
+    const useDataPersistence = await loadHookAs('main');
+    const { props, setters } = makeProps();
+    const store = {
+      ...STORE,
+      'day-planner-routines-date': '2000-01-01',
+      'day-planner-today-routines': JSON.stringify([{ id: 'chip-a' }, { id: 7 }]),
+      'day-planner-removed-today-routine-ids': JSON.stringify({ 'mid-day': '2000-01-01T15:00:00.000Z' }),
+    };
+    globalThis.localStorage.getItem = vi.fn((k) => store[k] ?? null);
+
+    useDataPersistence(props).loadData();
+
+    const midnight = new Date(); midnight.setHours(0, 0, 0, 0);
+    const expected = {
+      'mid-day': '2000-01-01T15:00:00.000Z',
+      'chip-a': midnight.toISOString(),
+      '7': midnight.toISOString(),
+    };
+    expect(setters.setTodayRoutines).toHaveBeenCalledWith([]);
+    expect(setters.setRemovedTodayRoutineIds).toHaveBeenCalledWith(expected);
+    const written = Object.fromEntries(setItem.mock.calls);
+    expect(JSON.parse(written['day-planner-removed-today-routine-ids'])).toEqual(expected);
+    expect(removeItem).not.toHaveBeenCalled();
   });
 
   it('writes nothing to localStorage in tray mode', async () => {

--- a/src/hooks/useRoutines.js
+++ b/src/hooks/useRoutines.js
@@ -42,6 +42,22 @@ export const resetRoutineCompletionsForToday = (
   return { completions, timestamps };
 };
 
+// Roll the routine-removal receipts (removedTodayRoutineIds, {id -> ISO}) into a
+// new day: every chip the rollover clears gets a receipt stamped at local
+// midnight, MERGED into the existing map. Mid-day receipts must survive for
+// peers that were offline (the vault merges this bundle grow-only and the
+// 60-day retention prunes it), and a bare wipe only pushed an empty bundle the
+// next pull undid, one pointless write per new day. Shared by the
+// open-across-midnight effect below and the launch-on-a-new-day path in
+// useDataPersistence so the two paths agree.
+export const rolloverRemovedTodayRoutineIds = (existing = {}, clearedRoutines = [], midnightIso) => {
+  const next = { ...(existing || {}) };
+  for (const r of clearedRoutines || []) {
+    if (r && r.id !== undefined && r.id !== null) next[String(r.id)] = midnightIso;
+  }
+  return next;
+};
+
 // Sanitize a MERGED (sync-apply) routine-completion payload for today (#1196
 // symptom 2). A merged payload can carry a PRIOR-day completion — e.g. this
 // device was offline overnight, so it never stamped a midnight tombstone for a
@@ -152,8 +168,7 @@ const useRoutines = ({ currentTime, onboardingProgress, setOnboardingProgress, h
       // clears the tombstone on local re-add), so fresh placements still win.
       const midnightIso = startOfTodayIso();
       if (todayRoutines.length > 0) {
-        const withCleared = { ...removedTodayRoutineIds };
-        for (const r of todayRoutines) withCleared[String(r.id)] = midnightIso;
+        const withCleared = rolloverRemovedTodayRoutineIds(removedTodayRoutineIds, todayRoutines, midnightIso);
         setRemovedTodayRoutineIds(withCleared);
         localStorage.setItem('day-planner-removed-today-routine-ids', JSON.stringify(withCleared));
       }

--- a/src/hooks/useRoutines.test.js
+++ b/src/hooks/useRoutines.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resetRoutineCompletionsForToday, sanitizeMergedRoutineCompletions, startOfTodayIso } from './useRoutines.js';
+import { resetRoutineCompletionsForToday, rolloverRemovedTodayRoutineIds, sanitizeMergedRoutineCompletions, startOfTodayIso } from './useRoutines.js';
 
 const TODAY = '2026-07-03';
 const MIDNIGHT = '2026-07-03T00:00:00.000Z'; // local-midnight stand-in for the tests
@@ -116,5 +116,25 @@ describe('sanitizeMergedRoutineCompletions (#1196 symptom 2 — sync-apply)', ()
     );
     expect(completions).toEqual({ done: TODAY });
     expect(timestamps).toEqual({ done: TODAY_MORNING_TS, stale: MIDNIGHT, marker: TODAY_MORNING_TS });
+  });
+});
+
+describe('rolloverRemovedTodayRoutineIds', () => {
+  it('keeps every existing receipt and stamps a midnight receipt per cleared chip', () => {
+    const existing = { 'mid-day': YESTERDAY_TS, old: '2026-05-01T00:00:00.000Z' };
+    const rolled = rolloverRemovedTodayRoutineIds(existing, [{ id: 'a' }, { id: 42 }], MIDNIGHT);
+    expect(rolled).toEqual({ ...existing, a: MIDNIGHT, '42': MIDNIGHT });
+    // Pure: the input map is untouched.
+    expect(existing).toEqual({ 'mid-day': YESTERDAY_TS, old: '2026-05-01T00:00:00.000Z' });
+  });
+
+  it('a cleared chip that already had a mid-day receipt is re-stamped at midnight (the rollover is the later event)', () => {
+    const rolled = rolloverRemovedTodayRoutineIds({ a: YESTERDAY_TS }, [{ id: 'a' }], MIDNIGHT);
+    expect(rolled).toEqual({ a: MIDNIGHT });
+  });
+
+  it('with nothing stored and nothing cleared the result is an empty map, never a wipe of a peer-held receipt', () => {
+    expect(rolloverRemovedTodayRoutineIds(undefined, undefined, MIDNIGHT)).toEqual({});
+    expect(rolloverRemovedTodayRoutineIds({ keep: YESTERDAY_TS }, [], MIDNIGHT)).toEqual({ keep: YESTERDAY_TS });
   });
 });


### PR DESCRIPTION
## Summary

The removal receipts for today's routines (`removedTodayRoutineIds`, an id to ISO map) had two owners that disagreed about a new day. The open-across-midnight rollover in `useRoutines.js` keeps the map and adds a midnight receipt per cleared chip, so peers that were offline do not resurrect yesterday's chips and old receipts age out through the 60-day retention. The launch-on-a-new-day path in `useDataPersistence.js` wiped the map.

The vault merges this bundle grow-only, so the wipe never stuck: it pushed an empty bundle, the next pull brought every peer-held receipt back, and the client pushed the full map again. One pointless write per launch on a new day, seen in the 2026-09-09 morning console. No visible effect on routines, which cleared correctly on both paths.

## Changes

- `src/hooks/useRoutines.js`: `rolloverRemovedTodayRoutineIds(existing, clearedChips, midnightIso)` is the one rule. Pure, returns a new map with every existing receipt kept and a midnight receipt per cleared chip. The rollover effect uses it.
- `src/hooks/useDataPersistence.js`: on a new day the launch path reads the stored chips and receipts, rolls them with the same helper, sets state and persists the result. Tray mode still never writes.
- Tests: three cases for the helper in `useRoutines.test.js`; the persistence test that asserted the wipe now asserts the roll, plus a new case with stored chips and a mid-day receipt.

Full suite green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_