### PR TITLE
iOS: Keychain mirror of the vault connection, cloud sync preference, and cached keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ The sync engine resolves conflicts at the task level using timestamps, not last-
 
 **Setup:** Settings → Cloud Sync → choose Nextcloud or Generic WebDAV → enter URL and credentials. Syncs automatically every 15 minutes or on demand.
 
-**End-to-end encryption** is available as an opt-in. When enabled, all sync data is encrypted with AES-256-GCM before leaving your device, and your passphrase never leaves your device and the server never sees plaintext. On Android, the derived key is stored in the hardware-backed Android Keystore. Enable in **Settings → Cloud Sync → Enable end-to-end encryption**.
+**End-to-end encryption** is available as an opt-in. When enabled, all sync data is encrypted with AES-256-GCM before leaving your device, and your passphrase never leaves your device and the server never sees plaintext. On Android, the derived key is stored in the hardware-backed Android Keystore; on iOS it is kept in the device Keychain, along with the GLANCEvault connection, so it survives a WebKit storage purge. Enable in **Settings → Cloud Sync → Enable end-to-end encryption**.
 
 ### CalDAV / iCal Calendar Import
 

--- a/dayglance-ios/DayGlance/Bridges/SecureStoreBridge.swift
+++ b/dayglance-ios/DayGlance/Bridges/SecureStoreBridge.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Security
+
+/// Device-local secure store behind the `secureGet` / `secureSet` bridge methods.
+///
+/// The web layer keeps everything in WKWebView storage, and iOS treats that
+/// storage as evictable: a routine reboot purged it (2026-09-09) and the phone
+/// came back on onboarding with no vault connection. This store is the native
+/// mirror the web layer restores from on launch: the GLANCEvault connection,
+/// the cloud sync preference, and the cached encryption-key records
+/// (src/utils/nativeSecureStore.js names the slots).
+///
+/// Items are generic passwords under one service, one per slot, protected by
+/// kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly: readable in the background
+/// once the device has been unlocked since boot, and never carried to iCloud
+/// Keychain (the vault device token is per device, and the app never puts a
+/// secret where another copy could read it). The sync passphrase itself is
+/// not stored here; only what the web layer already cached on the device.
+///
+/// Called synchronously from the JS bridge on a WKURLSchemeHandler thread.
+final class SecureStoreBridge {
+
+    static let shared = SecureStoreBridge()
+
+    private let service = "com.dayglance.app.securestore"
+
+    /// The stored value, or "" when the slot is empty or unreadable. The JS
+    /// wrapper treats "" as "no value", so the empty string is never a value.
+    func get(slot: String) -> String {
+        var query = baseQuery(slot: slot)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else { return "" }
+        return value
+    }
+
+    /// Writes the value, or deletes the slot when the value is nil or empty.
+    /// Returns "true" on success, "false" otherwise.
+    func set(slot: String, value: String?) -> String {
+        guard let value, !value.isEmpty, let data = value.data(using: .utf8) else {
+            let status = SecItemDelete(baseQuery(slot: slot) as CFDictionary)
+            return (status == errSecSuccess || status == errSecItemNotFound) ? "true" : "false"
+        }
+        let query = baseQuery(slot: slot)
+        let attributes: [String: Any] = [kSecValueData as String: data]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecSuccess { return "true" }
+        if updateStatus != errSecItemNotFound { return "false" }
+        var add = query
+        add[kSecValueData as String] = data
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        return SecItemAdd(add as CFDictionary, nil) == errSecSuccess ? "true" : "false"
+    }
+
+    private func baseQuery(slot: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: slot,
+        ]
+    }
+}

--- a/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
+++ b/dayglance-ios/DayGlance/WebView/BridgeSchemeHandler.swift
@@ -288,6 +288,16 @@ final class BridgeSchemeHandler: NSObject, WKURLSchemeHandler {
             VaultSseBridge.shared.stop()
             return "null"
 
+        // Secure store: the Keychain mirror of the web layer's connection state
+        // and cached key records (SecureStoreBridge). "" means no value.
+        case "secureGet":
+            guard let slot = args.first as? String, !slot.isEmpty else { return "" }
+            return SecureStoreBridge.shared.get(slot: slot)
+        case "secureSet":
+            guard let slot = args.first as? String, !slot.isEmpty else { return "false" }
+            let value = args.count >= 2 ? args[1] as? String : nil
+            return SecureStoreBridge.shared.set(slot: slot, value: value)
+
         default:
             return "null"
         }

--- a/docs/obsidian-buildout-spec.md
+++ b/docs/obsidian-buildout-spec.md
@@ -170,14 +170,20 @@ The Phase 1 section below reflects the delivered design, not a proposal.
   storage as evictable and a reboot is one of the moments it may reclaim it.
   No data was lost: the DB engine pulls before it pushes, so an empty device
   reconnecting to the vault repopulates from the fleet and pushes nothing
-  (a new device id appears in the devices table). Deferred follow-up, after
-  5.0.0: mirror the vault connection into a native store the shell owns
-  (Keychain for the device token, account id and passphrase, `UserDefaults`
-  for the URL and flags) and hand it back to the web layer at launch when
-  localStorage has none; consider the same for the iCloud-sync preference so
-  a purged device reconnects without a hand-entered setup. The account root
-  key and passphrase must still never be written anywhere the plugin can
-  read. Android's WebView store did not exhibit this and is not in scope.
+  (a new device id appears in the devices table). **Built after 5.0.0**
+  (`SecureStoreBridge.swift`, `src/utils/nativeSecureStore.js`): the shell's
+  Keychain holds a device-local mirror of the vault connection, the cloud
+  sync preference, the file-tier key record and the DB root key record,
+  written on every change and read back at launch when web storage has none;
+  existing installs move their IndexedDB key records across once. What is
+  NOT mirrored, by choice: the sync passphrase itself, and the vault intents
+  root key (a non-extractable HKDF key the intents package derives; it
+  cannot be exported). So a purged phone with vault intents enabled restores
+  its connection and its sync keys and then prompts once for the passphrase,
+  which re-derives the intents key; a phone without intents restores
+  silently. Storing the passphrase in the Keychain would remove that one
+  prompt and is a one-slot change if the owner rules for it. Android's
+  WebView store did not exhibit this and is not in scope.
 
 ### 2.6 Field incident record (2026-09-07): the 24-row tombstone replay
 

--- a/src/hooks/useCloudSync.js
+++ b/src/hooks/useCloudSync.js
@@ -4,10 +4,25 @@ import { isVaultEnabled } from '../sync/vaultConfig.js';
 import { restoreDbRootKey } from '../sync/dbEngine.js';
 import { isDbIntentsEnabled } from '../intents/dbIntentsConfig.js';
 import { loadVaultIntentsRootKey } from '../intents/intentsKeyStore.js';
+import { SECURE_SLOT, secureGet, secureSet, secureStoreAvailable } from '../utils/nativeSecureStore.js';
 
 const useCloudSync = () => {
   const [cloudSyncConfig, setCloudSyncConfig] = useState(() => {
-    const saved = localStorage.getItem('day-planner-cloud-sync-config');
+    let saved = localStorage.getItem('day-planner-cloud-sync-config');
+    if (!saved && secureStoreAvailable()) {
+      // iOS: WebKit may purge web storage (a reboot did, 2026-09-09). The
+      // shell's Keychain mirror (utils/nativeSecureStore.js) restores the
+      // preference; the persist effect below keeps the mirror current.
+      const mirrored = secureGet(SECURE_SLOT.cloudSyncConfig);
+      if (mirrored) {
+        try {
+          JSON.parse(mirrored);
+          localStorage.setItem('day-planner-cloud-sync-config', mirrored);
+          saved = mirrored;
+          console.info('[cloud-sync] preference restored from the device secure store');
+        } catch { /* unreadable mirror: start unconfigured */ }
+      }
+    }
     if (!saved) return null;
     const config = JSON.parse(saved);
     // Generic WebDAV users pre-1.0.3: webdavUrl contained the full folder path
@@ -66,6 +81,8 @@ const useCloudSync = () => {
     } else {
       localStorage.removeItem('day-planner-cloud-sync-config');
     }
+    // iOS secure-store mirror (no-op elsewhere); a clear clears the mirror.
+    secureSet(SECURE_SLOT.cloudSyncConfig, cloudSyncConfig ? JSON.stringify(cloudSyncConfig) : null);
   }, [cloudSyncConfig]);
 
   // On mount: attempt to restore the cached encryption key(s) from device storage

--- a/src/sync/dbEngine.js
+++ b/src/sync/dbEngine.js
@@ -35,6 +35,7 @@ import { createVaultClient } from '@glance-apps/sync/src/vaultClient.js';
 import { getVaultConfig, isVaultEnabled } from './vaultConfig.js';
 import { markInitialPullComplete } from './initialPull.js';
 import { getDeviceId } from './deviceId.js';
+import { SECURE_SLOT, secureGet, secureSet, secureStoreAvailable, readIndexedDbRecord } from '../utils/nativeSecureStore.js';
 import {
   getLocalEntity as adapterGetLocalEntity,
   applyRemoteEntity as adapterApplyRemoteEntity,
@@ -111,19 +112,27 @@ export function resetVaultSyncCursor(storageKeyPrefix = DEFAULT_STORAGE_KEY_PREF
 const VAULT_KEY_SLOT = 'db';
 
 // Where the per-account DB root key is stored: the Android OS keystore on the
-// Android shell (mirrors the file tier in crypto.js), IndexedDB everywhere else
-// (web AND iOS). Centralized so the engine and resetDbRootKey agree.
+// Android shell (mirrors the file tier in crypto.js), the iOS shell's Keychain
+// (utils/nativeSecureStore.js, through the same native hooks and record shape),
+// IndexedDB on web and Electron. Centralized so the engine and resetDbRootKey
+// agree.
 //
 // iOS gotcha (the every-launch passphrase re-prompt): iOS exposes
 // window.DayGlanceNative as a Proxy whose every property reads truthy, so the
 // old `!!bridge?.httpRequest` native-app check returned true on iOS and routed
 // it through the bridge's (non-functional, proxy-faked) keystore methods. The
 // DB root key was therefore never actually persisted, so restoreDbRootKey()
-// returned false on every launch and the passphrase modal reappeared. Only
-// Android — which sets no DayGlanceIOS marker and exposes a REAL getSyncKey —
-// should use the native keystore; iOS uses IndexedDB (which persists across
-// launches), exactly as src/utils/crypto.js does for the file tier.
+// returned false on every launch and the passphrase modal reappeared. iOS is
+// therefore detected by its explicit marker and routed to its REAL secure-store
+// methods; only Android (no marker, a real getSyncKey) uses the Keystore path.
 export function nativeKeyConfig() {
+  if (secureStoreAvailable()) {
+    return {
+      cryptoDBName: CRYPTO_DB_NAME,
+      nativeGetSyncKey: () => secureGet(SECURE_SLOT.dbRootKey),
+      nativeStoreSyncKey: (val) => secureSet(SECURE_SLOT.dbRootKey, val),
+    };
+  }
   const bridge = typeof window !== 'undefined' ? window.DayGlanceNative : null;
   const isAndroid = !!bridge && !window.DayGlanceIOS && !!bridge.getSyncKey;
   if (!isAndroid) {
@@ -160,7 +169,28 @@ export async function resetDbRootKey() {
 // Returns false (not throwing) when no key is cached, so the caller can show the
 // passphrase prompt.
 export async function restoreDbRootKey() {
-  try { return await initDbRootKey(nativeKeyConfig()); } catch { return false; }
+  try {
+    const cfg = nativeKeyConfig();
+    if (await initDbRootKey(cfg)) return true;
+    // Existing iOS installs cached the root key in IndexedDB before the Keychain
+    // mirror existed. Move it once so the upgrade never re-prompts.
+    if (secureStoreAvailable() && await migrateLegacyIosDbRootKey()) {
+      console.info('[vault] DB root key moved from IndexedDB to the device secure store');
+      return await initDbRootKey(cfg);
+    }
+    return false;
+  } catch { return false; }
+}
+
+// The package's IndexedDB record is {id, rootBytes: number[], salt: number[]}
+// in `${CRYPTO_DB_NAME}-db` / 'db-root-keys'; its native record is the same
+// pair as base64 JSON.
+async function migrateLegacyIosDbRootKey() {
+  const record = await readIndexedDbRecord(`${CRYPTO_DB_NAME}-db`, 'db-root-keys', 'db-root-key');
+  if (!record || !record.rootBytes) return false;
+  const rootBytes = Array.from(new Uint8Array(record.rootBytes));
+  const salt = Array.from(record.salt || []);
+  return secureSet(SECURE_SLOT.dbRootKey, btoa(JSON.stringify({ rootBytes, salt })));
 }
 
 const clone = (x) => (x == null ? x : JSON.parse(JSON.stringify(x)));

--- a/src/sync/dbEngine.nativeKey.test.js
+++ b/src/sync/dbEngine.nativeKey.test.js
@@ -1,18 +1,20 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { nativeKeyConfig } from './dbEngine.js';
 
-// Regression for the iOS-only "passphrase prompt on every launch" bug.
+// Regression for the iOS-only "passphrase prompt on every launch" bug, plus
+// the iOS secure-store route.
 //
 // The GLANCEvault DB root key must persist across launches so a vault-enabled
 // device unlocks silently. It lives in the Android OS keystore on the Android
-// shell and in IndexedDB everywhere else (web AND iOS). The bug: iOS exposes
-// window.DayGlanceNative as a Proxy whose every property reads truthy, so the
-// old `!!bridge.httpRequest` native-app check matched on iOS and routed the key
-// through the proxy's non-functional keystore methods — it was never persisted,
-// so the passphrase modal reappeared on every launch. Only Android (real
-// getSyncKey, no DayGlanceIOS marker) may use the native keystore.
+// shell, in the iOS shell's Keychain (secureGet/secureSet, the mirror that
+// survives a WebKit storage purge), and in IndexedDB on web and Electron. The
+// old bug: iOS exposes window.DayGlanceNative as a Proxy whose every property
+// reads truthy, so the old `!!bridge.httpRequest` native-app check matched on
+// iOS and routed the key through the proxy's non-functional Android keystore
+// methods — it was never persisted, so the passphrase modal reappeared on every
+// launch. iOS is now routed by its explicit marker to its own real methods.
 
-describe('nativeKeyConfig — native keystore only on Android, IndexedDB on iOS/web', () => {
+describe('nativeKeyConfig — Android keystore, iOS secure store, IndexedDB on web', () => {
   const origWindow = Object.prototype.hasOwnProperty.call(global, 'window') ? global.window : undefined;
   const hadWindow = Object.prototype.hasOwnProperty.call(global, 'window');
   afterEach(() => {
@@ -28,15 +30,19 @@ describe('nativeKeyConfig — native keystore only on Android, IndexedDB on iOS/
     expect(cfg.nativeStoreSyncKey).toBeNull();
   });
 
-  it('iOS (all-truthy Proxy bridge + DayGlanceIOS marker): uses IndexedDB, NOT the proxy keystore', () => {
-    // iOS proxies every property lookup to a truthy function — exactly the trap
-    // the old `!!bridge.httpRequest` check fell into.
-    const proxy = new Proxy({}, { get: () => () => 'truthy' });
+  it('iOS (DayGlanceIOS marker): uses the secure store under its own slot, never the Android keystore names', () => {
+    const calls = [];
+    // The proxy still answers every name; the config must call secureGet /
+    // secureSet by name and nothing else.
+    const proxy = new Proxy({}, {
+      get: (_, name) => (...args) => { calls.push([name, ...args]); return name === 'secureGet' ? 'k' : 'true'; },
+    });
     global.window = { DayGlanceNative: proxy, DayGlanceIOS: {} };
     const cfg = nativeKeyConfig();
     expect(cfg.cryptoDBName).toBe('dayglance-db-crypto');
-    expect(cfg.nativeGetSyncKey).toBeNull();
-    expect(cfg.nativeStoreSyncKey).toBeNull();
+    expect(cfg.nativeGetSyncKey()).toBe('k');
+    expect(cfg.nativeStoreSyncKey('val')).toBe(true);
+    expect(calls).toEqual([['secureGet', 'db-root-key'], ['secureSet', 'db-root-key', 'val']]);
   });
 
   it('Android (real getSyncKey, no DayGlanceIOS): uses the native keystore', () => {

--- a/src/sync/vaultConfig.js
+++ b/src/sync/vaultConfig.js
@@ -7,20 +7,48 @@
 // rejects this device's credential, honoured by every primitive. Imported as
 // the exported helper — never a string literal — so the key can't drift.
 import { credentialHaltKey } from '@glance-apps/sync/src/dbEngine.js';
+import { SECURE_SLOT, secureGet, secureSet, secureStoreAvailable } from '../utils/nativeSecureStore.js';
 
 const VAULT_CONFIG_KEY = 'dayglance-vault-config';
 // Must match the wrapper's DEFAULT_STORAGE_KEY_PREFIX (src/sync/dbEngine.js).
 const VAULT_STORAGE_KEY_PREFIX = 'dayglance-vault';
 
-/** @returns {{enabled:boolean, vaultUrl:string, vaultToken:string, accountId:string}|null} */
-export function getVaultConfig() {
+// iOS mirror (utils/nativeSecureStore.js): the shell's Keychain holds a copy
+// of this config, written on every save and read back once per session when
+// web storage has none. WebKit purged the phone's storage after a reboot
+// (2026-09-09) and the connection was gone with it; the mirror is what brings
+// it back without a hand-entered setup. One read per session: a device that
+// never configured a vault must not pay a bridge call on every isVaultEnabled().
+let secureRestoreTried = false;
+
+function restoreVaultConfigFromSecureStore() {
+  if (secureRestoreTried || !secureStoreAvailable()) return null;
+  secureRestoreTried = true;
+  const mirrored = secureGet(SECURE_SLOT.vaultConfig);
+  if (!mirrored) return null;
   try {
-    const saved = localStorage.getItem(VAULT_CONFIG_KEY);
-    return saved ? JSON.parse(saved) : null;
+    const cfg = JSON.parse(mirrored);
+    if (!cfg || typeof cfg !== 'object') return null;
+    localStorage.setItem(VAULT_CONFIG_KEY, JSON.stringify(cfg));
+    console.info('[vault] connection restored from the device secure store');
+    return cfg;
   } catch {
     return null;
   }
 }
+
+/** @returns {{enabled:boolean, vaultUrl:string, vaultToken:string, accountId:string}|null} */
+export function getVaultConfig() {
+  try {
+    const saved = localStorage.getItem(VAULT_CONFIG_KEY);
+    if (saved) return JSON.parse(saved);
+  } catch {
+    return null;
+  }
+  return restoreVaultConfigFromSecureStore();
+}
+
+export function _resetVaultConfigSecureRestoreForTests() { secureRestoreTried = false; }
 
 export function setVaultConfig(cfg) {
   // HALT EXIT (2.0.0 adoption, ruling 4 — the minimal version): the package
@@ -42,6 +70,9 @@ export function setVaultConfig(cfg) {
   } catch { /* storage unavailable — the halt read would fail the same way */ }
   if (cfg) localStorage.setItem(VAULT_CONFIG_KEY, JSON.stringify(cfg));
   else localStorage.removeItem(VAULT_CONFIG_KEY);
+  // Mirror to the iOS secure store (no-op elsewhere); a clear clears the mirror.
+  secureSet(SECURE_SLOT.vaultConfig, cfg ? JSON.stringify(cfg) : null);
+  secureRestoreTried = true; // web storage is now authoritative for this session
 }
 
 // True only when the vault is fully configured AND toggled on. Everything in the

--- a/src/sync/vaultConfig.test.js
+++ b/src/sync/vaultConfig.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getVaultConfig, setVaultConfig, isVaultEnabled, VAULT_CONFIG_KEY,
+  _resetVaultConfigSecureRestoreForTests,
+} from './vaultConfig.js';
+
+// The iOS secure-store mirror of the GLANCEvault connection: restored once per
+// session when web storage has none (the WebKit purge of 2026-09-09), kept
+// current on every save, cleared on a clear.
+
+const CFG = { enabled: true, vaultUrl: 'https://vault.example', vaultToken: 'tok', accountId: 'acct' };
+
+function fakeStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => { m.set(k, String(v)); },
+    removeItem: (k) => { m.delete(k); },
+  };
+}
+
+describe('vaultConfig secure-store mirror', () => {
+  const hadWindow = Object.prototype.hasOwnProperty.call(globalThis, 'window');
+  const origWindow = hadWindow ? globalThis.window : undefined;
+  let secureGetFn;
+  let secureSetFn;
+  let mirror;
+
+  beforeEach(() => {
+    _resetVaultConfigSecureRestoreForTests();
+    globalThis.localStorage = fakeStorage();
+    mirror = null;
+    secureGetFn = vi.fn(() => mirror ?? '');
+    secureSetFn = vi.fn((_, v) => { mirror = v; return 'true'; });
+    globalThis.window = { DayGlanceIOS: true, DayGlanceNative: { secureGet: secureGetFn, secureSet: secureSetFn } };
+  });
+
+  afterEach(() => {
+    delete globalThis.localStorage;
+    if (hadWindow) globalThis.window = origWindow;
+    else delete globalThis.window;
+  });
+
+  it('restores the connection from the mirror when web storage is empty, and asks the bridge only once', () => {
+    mirror = JSON.stringify(CFG);
+    expect(getVaultConfig()).toEqual(CFG);
+    expect(JSON.parse(localStorage.getItem(VAULT_CONFIG_KEY))).toEqual(CFG);
+    expect(isVaultEnabled()).toBe(true);
+    getVaultConfig();
+    expect(secureGetFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('with no mirror either, reports unconfigured and does not keep asking', () => {
+    expect(getVaultConfig()).toBeNull();
+    expect(isVaultEnabled()).toBe(false);
+    expect(getVaultConfig()).toBeNull();
+    expect(secureGetFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('web storage wins when it has a config; the mirror is not consulted', () => {
+    localStorage.setItem(VAULT_CONFIG_KEY, JSON.stringify({ ...CFG, accountId: 'local' }));
+    mirror = JSON.stringify(CFG);
+    expect(getVaultConfig().accountId).toBe('local');
+    expect(secureGetFn).not.toHaveBeenCalled();
+  });
+
+  it('saving mirrors the config, and clearing clears the mirror', () => {
+    setVaultConfig(CFG);
+    expect(secureSetFn).toHaveBeenLastCalledWith('vault-config', JSON.stringify(CFG));
+    expect(mirror).toBe(JSON.stringify(CFG));
+    setVaultConfig(null);
+    expect(secureSetFn).toHaveBeenLastCalledWith('vault-config', null);
+    expect(localStorage.getItem(VAULT_CONFIG_KEY)).toBeNull();
+  });
+
+  it('an unreadable mirror is ignored', () => {
+    mirror = '{not json';
+    expect(getVaultConfig()).toBeNull();
+    expect(localStorage.getItem(VAULT_CONFIG_KEY)).toBeNull();
+  });
+
+  it('off iOS nothing touches a bridge', () => {
+    globalThis.window = { DayGlanceNative: { secureGet: secureGetFn, secureSet: secureSetFn } }; // Android shape
+    expect(getVaultConfig()).toBeNull();
+    setVaultConfig(CFG);
+    expect(secureGetFn).not.toHaveBeenCalled();
+    expect(secureSetFn).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -14,18 +14,44 @@ import {
   hasEncryptionReady,
   isEncryptedEnvelope,
 } from '@glance-apps/sync';
+import { SECURE_SLOT, secureGet, secureSet, secureStoreAvailable, readIndexedDbRecord } from './nativeSecureStore.js';
+
+const CRYPTO_DB_NAME = 'dayglance-crypto';
 
 // iOS uses a Proxy for DayGlanceNative that makes every property lookup truthy,
 // so we must explicitly exclude iOS before treating the native bridge as Android.
+// iOS has its own path: the file-tier key record is kept in the shell's
+// Keychain (utils/nativeSecureStore.js) through the package's native hooks, the
+// same record shape Android stores in its Keystore, so a WebKit storage purge
+// no longer costs the key. Web and Electron stay on IndexedDB.
 function getDayGlanceConfig() {
+  if (secureStoreAvailable()) {
+    return {
+      cryptoDBName: CRYPTO_DB_NAME,
+      nativeGetSyncKey: () => secureGet(SECURE_SLOT.syncKey),
+      nativeStoreSyncKey: (val) => secureSet(SECURE_SLOT.syncKey, val),
+    };
+  }
   const isAndroid = typeof window !== 'undefined' &&
     !window.DayGlanceIOS &&
     !!window.DayGlanceNative?.getSyncKey;
   return {
-    cryptoDBName: 'dayglance-crypto',
+    cryptoDBName: CRYPTO_DB_NAME,
     nativeGetSyncKey: isAndroid ? () => window.DayGlanceNative.getSyncKey() : null,
     nativeStoreSyncKey: isAndroid ? (val) => window.DayGlanceNative.storeSyncKey(val) : null,
   };
+}
+
+// Existing iOS installs cached the key in IndexedDB before the Keychain mirror
+// existed. Move it once so the upgrade never re-prompts for the passphrase.
+// The IndexedDB record is {id, rawKey: ArrayBuffer, salt: number[]}; the native
+// record is the base64 JSON {rawKey: number[], salt: number[]} the package reads.
+async function migrateLegacyIosSyncKey() {
+  const record = await readIndexedDbRecord(CRYPTO_DB_NAME, 'keys', 'sync-key');
+  if (!record || !record.rawKey) return false;
+  const rawKey = Array.from(new Uint8Array(record.rawKey));
+  const salt = Array.from(record.salt || []);
+  return secureSet(SECURE_SLOT.syncKey, btoa(JSON.stringify({ rawKey, salt })));
 }
 
 export { setSyncPassphrase, getSyncPassphrase, hasEncryptionReady, isEncryptedEnvelope };
@@ -34,4 +60,13 @@ export const encryptData        = (data)         => _encryptData(data, getDayGla
 export const decryptData        = (envelope)     => _decryptData(envelope, getDayGlanceConfig());
 export const setupEncryptionKey = (passphrase)   => _setupEncryptionKey(passphrase, getDayGlanceConfig());
 export const clearEncryptionKey = ()             => _clearEncryptionKey(getDayGlanceConfig());
-export const initSessionKey     = ()             => _initSessionKey(getDayGlanceConfig());
+export const initSessionKey     = async () => {
+  const cfg = getDayGlanceConfig();
+  if (await _initSessionKey(cfg)) return true;
+  if (!secureStoreAvailable()) return false;
+  if (await migrateLegacyIosSyncKey()) {
+    console.info('[crypto] file-tier key moved from IndexedDB to the device secure store');
+    return _initSessionKey(cfg);
+  }
+  return false;
+};

--- a/src/utils/nativeSecureStore.js
+++ b/src/utils/nativeSecureStore.js
@@ -1,0 +1,87 @@
+// The iOS shell's Keychain-backed secure store (SecureStoreBridge.swift).
+//
+// On iOS every app record and every connection setting lives in WKWebView
+// storage, which iOS treats as evictable: a routine reboot purged it
+// (2026-09-09) and the phone came back on onboarding with an empty GLANCEvault
+// configuration and no cached keys. This module is the web side of the native
+// mirror: the connection state and the cached key records are written here
+// whenever they change, and read back on launch when web storage has none.
+//
+// Android keeps its own Keystore path (getSyncKey / storeSyncKey) and the web
+// and Electron builds keep IndexedDB; on those platforms every call here is an
+// inert no-op. The sync passphrase itself is never stored: after a purge a
+// device that needs a key it cannot restore prompts once, as it does today.
+//
+// The iOS check is inlined (the same test as native.js isNativeIOS) so this
+// module has no imports: tests that mock native.js keep working unchanged.
+
+export const SECURE_SLOT = Object.freeze({
+  // JSON of the GLANCEvault connection ({enabled, vaultUrl, vaultToken, accountId}).
+  vaultConfig: 'vault-config',
+  // JSON of the cloud sync preference (day-planner-cloud-sync-config).
+  cloudSyncConfig: 'cloud-sync-config',
+  // The file-tier AES key record ({rawKey, salt}) as base64 JSON, the same
+  // shape @glance-apps/sync stores in the Android Keystore.
+  syncKey: 'sync-key',
+  // The GLANCEvault DB root key record ({rootBytes, salt}) as base64 JSON.
+  dbRootKey: 'db-root-key',
+});
+
+export const secureStoreAvailable = () =>
+  typeof window !== 'undefined' && !!window.DayGlanceIOS;
+
+/** @returns {string|null} the stored value, null when absent or unavailable */
+export function secureGet(slot) {
+  if (!secureStoreAvailable()) return null;
+  try {
+    const v = window.DayGlanceNative.secureGet(slot);
+    return typeof v === 'string' && v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Writes value, or clears the slot when value is null. @returns {boolean} */
+export function secureSet(slot, value) {
+  if (!secureStoreAvailable()) return false;
+  try {
+    const r = window.DayGlanceNative.secureSet(slot, value == null ? null : String(value));
+    return r === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * One-time migration read: a key record an earlier iOS build cached in
+ * IndexedDB. Resolves null when the database or the record is absent. Where
+ * the browser can list databases the open is skipped for a missing one, so
+ * the read never creates an empty database as a side effect.
+ */
+export async function readIndexedDbRecord(dbName, storeName, id) {
+  try {
+    if (typeof indexedDB === 'undefined') return null;
+    if (typeof indexedDB.databases === 'function') {
+      const names = (await indexedDB.databases()).map((d) => d.name);
+      if (!names.includes(dbName)) return null;
+    }
+    const db = await new Promise((resolve, reject) => {
+      const req = indexedDB.open(dbName);
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    try {
+      if (!db.objectStoreNames.contains(storeName)) return null;
+      return await new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, 'readonly');
+        const req = tx.objectStore(storeName).get(id);
+        req.onsuccess = () => resolve(req.result ?? null);
+        req.onerror = () => reject(req.error);
+      });
+    } finally {
+      try { db.close(); } catch { /* ignore */ }
+    }
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/nativeSecureStore.test.js
+++ b/src/utils/nativeSecureStore.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SECURE_SLOT, secureGet, secureSet, secureStoreAvailable } from './nativeSecureStore.js';
+
+const hadWindow = Object.prototype.hasOwnProperty.call(globalThis, 'window');
+const origWindow = hadWindow ? globalThis.window : undefined;
+
+function iosWindow(bridge = {}) {
+  globalThis.window = { DayGlanceIOS: true, DayGlanceNative: bridge };
+}
+
+describe('nativeSecureStore', () => {
+  afterEach(() => {
+    if (hadWindow) globalThis.window = origWindow;
+    else delete globalThis.window;
+  });
+
+  it('is unavailable off iOS: every call is an inert no-op', () => {
+    globalThis.window = { DayGlanceNative: { secureGet: vi.fn(), secureSet: vi.fn() } }; // Android shape
+    expect(secureStoreAvailable()).toBe(false);
+    expect(secureGet(SECURE_SLOT.vaultConfig)).toBeNull();
+    expect(secureSet(SECURE_SLOT.vaultConfig, 'x')).toBe(false);
+    expect(globalThis.window.DayGlanceNative.secureGet).not.toHaveBeenCalled();
+    expect(globalThis.window.DayGlanceNative.secureSet).not.toHaveBeenCalled();
+  });
+
+  it('reads a value on iOS and treats the empty string as absent', () => {
+    const secureGetFn = vi.fn((slot) => (slot === 'vault-config' ? '{"enabled":true}' : ''));
+    iosWindow({ secureGet: secureGetFn });
+    expect(secureStoreAvailable()).toBe(true);
+    expect(secureGet(SECURE_SLOT.vaultConfig)).toBe('{"enabled":true}');
+    expect(secureGet(SECURE_SLOT.syncKey)).toBeNull();
+    expect(secureGetFn).toHaveBeenCalledWith('vault-config');
+  });
+
+  it('writes a value and clears with null; the bridge answers "true"', () => {
+    const secureSetFn = vi.fn(() => 'true');
+    iosWindow({ secureSet: secureSetFn });
+    expect(secureSet(SECURE_SLOT.cloudSyncConfig, '{"enabled":true}')).toBe(true);
+    expect(secureSet(SECURE_SLOT.cloudSyncConfig, null)).toBe(true);
+    expect(secureSetFn.mock.calls).toEqual([
+      ['cloud-sync-config', '{"enabled":true}'],
+      ['cloud-sync-config', null],
+    ]);
+  });
+
+  it('a throwing bridge reads as absent and a failed write as false', () => {
+    iosWindow({ secureGet: () => { throw new Error('boom'); }, secureSet: () => { throw new Error('boom'); } });
+    expect(secureGet(SECURE_SLOT.dbRootKey)).toBeNull();
+    expect(secureSet(SECURE_SLOT.dbRootKey, 'v')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

A reboot purged the phone's WKWebView storage (2026-09-09) and dayGLANCE came back on onboarding with no vault connection and no cached keys. Everything lived in web storage, which iOS treats as evictable. This adds a device-local Keychain mirror the web layer restores from at launch, so a purged phone reconnects on its own.

## Native

- `SecureStoreBridge.swift`: Keychain generic-password items under one service, one per slot, `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` (readable in the background after first unlock, never carried to iCloud Keychain). Two bridge methods in `BridgeSchemeHandler.swift`: `secureGet(slot)` returns the value or `""`, `secureSet(slot, value)` writes or, with null, deletes.
- XcodeGen picks the new file up from the folder source; no project.yml change.

## Web

- `src/utils/nativeSecureStore.js`: the web side, inert off iOS (no imports, so tests that mock the native module are unaffected). Four slots: the GLANCEvault config, the cloud sync preference, the file-tier key record, the DB root key record.
- `src/sync/vaultConfig.js`: every save mirrors; when web storage has no config, the mirror is consulted once per session and written back. One bridge call per session at most for an unconfigured device.
- `src/hooks/useCloudSync.js`: same for the cloud sync preference, so iCloud sync comes back on too.
- `src/utils/crypto.js` and `src/sync/dbEngine.js`: on iOS the two key records go through the sync package's existing native hooks, the same base64 record shape Android's Keystore holds. On first launch after the update, a record still sitting in IndexedDB is moved across once, so existing iPhones do not get a passphrase prompt from the upgrade.

## Not mirrored, by choice

- The sync passphrase itself.
- The vault intents root key: a non-extractable HKDF key the intents package derives, so it cannot be exported.

Result: a purged phone without vault intents restores silently. One with intents enabled restores its connection and both sync keys, then prompts once for the passphrase, which re-derives the intents key. Storing the passphrase in the Keychain would remove that one prompt and is a one-slot addition if you rule for it. Recorded in spec section 2.5.

## Verification

- New tests: `nativeSecureStore.test.js` (availability, read, write, clear, throwing bridge), `vaultConfig.test.js` (restore once, storage wins, mirror on save and clear, unreadable mirror, off-iOS inert). `dbEngine.nativeKey.test.js` iOS case now asserts the secure-store route by name.
- Full suite green, lint clean.
- Device check, after installing the build: in iOS Settings, Safari, Advanced, Website Data is the wrong place (that is Safari's store). Instead: open the app once so it mirrors, then in Xcode's device window delete the app container's `Library/WebKit` folder, or simply wait for the next purge. On relaunch the vault connection and iCloud setting should be present and the first sync should pull without a passphrase prompt (or with exactly one, if vault intents are on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_