### PR TITLE
Late-observation gate for daily notes: newest mtime wins for text

### DIFF
--- a/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
+++ b/dayglance-obsidian-plugin/test/scope.scenarios.test.ts
@@ -657,6 +657,45 @@ describe('vault task scope, end to end', () => {
     expect(noBareLf(after)).toBe(true);
   });
 
+  it('21. LATE OBSERVATION (spec 2.7 ruling): a report whose mtime is older than the last applied one is dropped; equal and newer apply', async () => {
+    await bootWithScopedNote();
+    const DAILY = 'Daily/2026-09-11.md';
+    // A daily note with no task lines: the plugin has nothing to stamp, so the
+    // file's mtime is exactly what the test sets.
+    await s.write(DAILY, '## Notes\nMorning: coffee\n');
+    await s.settle();
+    await A.sync();
+    expect(A.state.dailyNotes['2026-09-11']!.text).toContain('Morning: coffee');
+    const applied = JSON.parse((globalThis as any).localStorage.getItem('dayglance-obsidian-last-applied-mtime'))['2026-09-11'];
+    expect(typeof applied).toBe('string');
+    // A newer edit lands and is applied; the memory advances.
+    await s.advance(5_000);
+    await s.write(DAILY, '## Notes\nMorning: coffee\nNoon: walk\n');
+    await s.settle();
+    await A.sync();
+    expect(A.state.dailyNotes['2026-09-11']!.text).toContain('Noon: walk');
+    const newerApplied = JSON.parse((globalThis as any).localStorage.getItem('dayglance-obsidian-last-applied-mtime'))['2026-09-11'];
+    expect(Date.parse(newerApplied)).toBeGreaterThan(Date.parse(applied));
+    // A lagging copy reports: older text under an mtime BEFORE the last
+    // applied one (a second desktop's Obsidian Sync copy, or a stream row
+    // delivered late). The text must not come back, and the memory holds.
+    await s.write(DAILY, '## Notes\nMorning: coffee\n');
+    s.file(DAILY).stat.mtime = Date.parse(applied) - 60_000;
+    const info = vi.spyOn(console, 'info');
+    await s.settle();
+    await A.sync();
+    expect(A.state.dailyNotes['2026-09-11']!.text).toContain('Noon: walk');
+    expect(info.mock.calls.some((c) => String(c[0]).includes('late observation skipped'))).toBe(true);
+    info.mockRestore();
+    expect(JSON.parse((globalThis as any).localStorage.getItem('dayglance-obsidian-last-applied-mtime'))['2026-09-11']).toBe(newerApplied);
+    // A genuinely newer edit still applies after the late one.
+    await s.advance(5_000);
+    await s.write(DAILY, '## Notes\nMorning: coffee\nNoon: walk\nEvening: read\n');
+    await s.settle();
+    await A.sync();
+    expect(A.state.dailyNotes['2026-09-11']!.text).toContain('Evening: read');
+  });
+
   it('9. a plugin reload republishes the pairing meta WITH the scope (harness finding)', async () => {
     await bootWithScopedNote();
     s.plugin.reload();

--- a/docs/obsidian-buildout-spec.md
+++ b/docs/obsidian-buildout-spec.md
@@ -313,10 +313,25 @@ than the record it replaced.
    (noteMtimes) for the tombstone and revival rules, which read the mtime,
    not the record.
 
-**Open, not built.** The late observation itself. An observation whose
-mtime is older than the note's last observed mtime is stale evidence, and
-today the merge still applies its text locally. Skipping it is a what-wins
-change between two observations of the same note and waits for a ruling.
+**The late observation itself: ruled and built (owner, 2026-09-09,
+Option B, "newest mtime wins for text").** An observation of a daily note
+whose real mtime is strictly older than the mtime of the last observation
+this device applied for that date is stale evidence and is dropped, text
+and revival evidence both (`utils/lateObservationGate.js`, harness scenario
+21). Equal or newer applies as before; an observation with no real mtime
+carries no evidence either way and always applies. One rule for both
+delivery paths, the bridge stream and this device's own scan (a lagging
+local copy is stale too). The memory is device-local
+(`dayglance-obsidian-last-applied-mtime`, dates older than 400 days
+pruned), never synced: a storage purge resets it and the next observation
+applies. This extends §3.10 ruling 6 (the note's mtime is the vault's
+statement time) from existence to text. Options considered: leave it
+(stale text shown on one device until the next change, a push every peer
+ignores); skip only an exact re-arrival of a copy this device already
+displaced (never drops new content, but a lagging peer's edit on top of a
+stale copy still gets through). Accepted edge: a note put back to an older
+version by a tool that preserves the old mtime is not seen until its next
+edit; Obsidian's own writes and restores set a fresh mtime.
 
 **Manual end to a running loop.** A small edit to the note on the desktop,
 saved from the app, stamps the real text newer than the stale copy and

--- a/src/hooks/useObsidianSync.js
+++ b/src/hooks/useObsidianSync.js
@@ -20,6 +20,7 @@ import { validateWikiNoteName } from '../utils/obsidianFilename.js';
 import { classifyVaultPaths } from '../utils/vaultPortability.js';
 import { mergeObsidianDailyNotes } from '../utils/mergeObsidianDailyNotes.js';
 import { mergeObsidianTasks, preserveObsidianAppFields, noteMtimesFromDailyNotes, noteMtimesFromScopedNotes } from '../utils/mergeObsidianTasks.js';
+import { applyLateObservationGate } from '../utils/lateObservationGate.js';
 import { detectObsidianDeletions, addObsidianTombstones, commitObsidianTombstones } from '../utils/obsidianDeletions.js';
 import { reattachTasksMetadata } from '../utils/obsidianTasksMetadata.js';
 import { obsidianHeartbeatState } from '../utils/obsidianHeartbeat.js';
@@ -871,14 +872,20 @@ export default function useObsidianSync({
               tombstones = commitObsidianTombstones(deletedNotes);
               console.info('[Obsidian] daily note(s) deleted in the vault; their copies drop now, their tasks after the confirmation hold:', deletedDates.map(([d]) => d).join(', '));
             }
-            setDailyNotes(prev => mergeObsidianDailyNotes(prev, applied.dailyNotes, tombstones));
             // The observed notes' mtimes are the revival evidence (§3.10
             // ruling 6): a scanned line whose tombstone predates its note's
             // mtime is re-admitted with lastModified lifted to that mtime.
             // Real mtimes only (audit fix M10): a note the plugin reported
             // without an mtime is no revival evidence at all.
-            const observedNoteMtimes = applied.noteMtimes
+            const observedNoteMtimesAll = applied.noteMtimes
               ?? { ...noteMtimesFromDailyNotes(applied.dailyNotes), ...noteMtimesFromScopedNotes(applied.scopedNotes) };
+            // LATE-OBSERVATION GATE (spec 2.7 ruling, 2026-09-09): a daily
+            // note observed with an mtime older than the last one this device
+            // applied is stale evidence; its text and its mtime are dropped.
+            // Same rule on the direct-scan path below.
+            const streamGate = applyLateObservationGate(applied.dailyNotes, observedNoteMtimesAll);
+            setDailyNotes(prev => mergeObsidianDailyNotes(prev, streamGate.dailyNotes, tombstones));
+            const observedNoteMtimes = streamGate.noteMtimes;
             // FIRST-IMPORT ASSIGNMENT (utils/obsidianUserScope.js): a task new
             // to the app is the vault's viewer's — here the pairing meta's
             // user, since every device on the account applies this stream.
@@ -1071,7 +1078,19 @@ export default function useObsidianSync({
       // new dailyNotes:…). Merge keeps other devices' dates, carries the prior
       // lastModified forward for unchanged text, and honors deletion tombstones so
       // a genuine vault deletion still propagates. See mergeObsidianDailyNotes.
-      setDailyNotes(prev => mergeObsidianDailyNotes(prev, result.dailyNotes, tombstones));
+      // The scanned notes' mtimes carry the revival evidence (§3.10 ruling 6),
+      // so a verbatim re-creation revives on a direct scan exactly as it does
+      // on an observation.
+      // Real mtimes only (audit fix M10): the native scan's "now" fallback for
+      // an old bridge build is a note-text stamp, not the vault's statement
+      // time, so it is excluded from the evidence (result.noteMtimes).
+      const scannedNoteMtimesAll = result.noteMtimes ?? noteMtimesFromDailyNotes(result.dailyNotes);
+      // LATE-OBSERVATION GATE (spec 2.7 ruling, 2026-09-09): this device's
+      // own copy can lag an observation it already applied (Obsidian Sync
+      // behind); an older mtime is stale evidence here too, one rule for
+      // both paths.
+      const scanGate = applyLateObservationGate(result.dailyNotes, scannedNoteMtimesAll);
+      setDailyNotes(prev => mergeObsidianDailyNotes(prev, scanGate.dailyNotes, tombstones));
 
       // BIN-VERSUS-VAULT (§3.10 ruling 5): a scanned line whose task sits in
       // the recycle bin restores it — the vault controls task existence, and
@@ -1103,13 +1122,8 @@ export default function useObsidianSync({
       // Update tasks/inbox — same merge-not-replace + honor-tombstones rule; RETAIN
       // prior Obsidian tasks this scan didn't produce (another device's vault),
       // drop only those with a deletion tombstone. See mergeObsidianTasks.
-      // The scanned notes' mtimes carry the revival evidence (§3.10 ruling 6),
-      // so a verbatim re-creation revives on a direct scan exactly as it does
-      // on an observation.
-      // Real mtimes only (audit fix M10): the native scan's "now" fallback for
-      // an old bridge build is a note-text stamp, not the vault's statement
-      // time, so it is excluded from the evidence (result.noteMtimes).
-      const scannedNoteMtimes = result.noteMtimes ?? noteMtimesFromDailyNotes(result.dailyNotes);
+      // Revival evidence without the dates the late-observation gate dropped.
+      const scannedNoteMtimes = scanGate.noteMtimes;
       // FIRST-IMPORT ASSIGNMENT (utils/obsidianUserScope.js): on direct
       // access the vault is on this device, so the viewer is this device's
       // user. Known tasks keep the app's own assignment.

--- a/src/utils/lateObservationGate.js
+++ b/src/utils/lateObservationGate.js
@@ -1,0 +1,106 @@
+// The late-observation gate for daily notes (owner ruling, 2026-09-09,
+// buildout spec 2.7: "newest mtime wins for text").
+//
+// A daily note's observations reach the app two ways: this device's own scan
+// of the file, and the plugin's reports over the bridge stream. Either can
+// arrive late: a stream row applied after a newer one, a second desktop's
+// plugin reporting its lagging Obsidian Sync copy, or this device's own copy
+// lagging behind an observation it already applied. The 2026-09-08 incident
+// was a lagging copy; the same day's console showed a note's stamp move
+// backwards at startup from a late row.
+//
+// The rule extends the existing one that a note's mtime is the vault's
+// statement time (revival, §3.10 ruling 6) to the note's TEXT: an observation
+// whose real mtime is strictly older than the mtime of the last observation
+// this device applied for that date is stale evidence and is dropped, text
+// and mtime both. Equal or newer applies as before. Memory is device-local
+// (never synced): a storage purge resets it and the next observation applies.
+// An observation with no real mtime carries no evidence either way and always
+// applies, exactly as it always did.
+//
+// Known edge, accepted in the ruling: a note put back to an older version by
+// a tool that preserves the old mtime is not seen until its next edit.
+// Obsidian's own writes and restores set a fresh mtime.
+
+export const LAST_APPLIED_MTIME_KEY = 'dayglance-obsidian-last-applied-mtime';
+// Daily-note dates older than this fall out of the memory map.
+export const LAST_APPLIED_RETAIN_DAYS = 400;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const defaultStorage = () => (typeof localStorage !== 'undefined' ? localStorage : null);
+
+export function readLastAppliedMtimes(storage = defaultStorage()) {
+  try {
+    const raw = storage?.getItem(LAST_APPLIED_MTIME_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function writeLastAppliedMtimes(map, storage = defaultStorage()) {
+  try {
+    if (!storage) return;
+    if (Object.keys(map).length === 0) storage.removeItem(LAST_APPLIED_MTIME_KEY);
+    else storage.setItem(LAST_APPLIED_MTIME_KEY, JSON.stringify(map));
+  } catch { /* storage unavailable: the gate degrades to "always apply" */ }
+}
+
+/**
+ * Pure gate. Returns the notes to apply, the evidence map without the skipped
+ * dates, the observations skipped, and the memory map to persist.
+ *
+ * @param {Record<string, object>} dailyNotes   date → observed note
+ * @param {Record<string, string>} noteMtimes   date → real mtime ISO (evidence)
+ * @param {Record<string, string>} lastApplied  date → mtime ISO of the last applied observation
+ * @param {{now?: number}} [opts]
+ */
+export function gateLateObservations(dailyNotes, noteMtimes, lastApplied, { now = Date.now() } = {}) {
+  const fresh = {};
+  const evidence = {};
+  const skipped = [];
+  const next = {};
+  const cutoff = now - LAST_APPLIED_RETAIN_DAYS * DAY_MS;
+  for (const [date, iso] of Object.entries(lastApplied || {})) {
+    const day = Date.parse(date);
+    if (Number.isNaN(day) || day >= cutoff) next[date] = iso;
+  }
+  for (const [date, note] of Object.entries(dailyNotes || {})) {
+    const mtime = noteMtimes?.[date];
+    const t = typeof mtime === 'string' ? Date.parse(mtime) : NaN;
+    if (Number.isNaN(t)) {
+      fresh[date] = note; // no real mtime: no evidence either way
+      continue;
+    }
+    const last = next[date] ? Date.parse(next[date]) : NaN;
+    if (!Number.isNaN(last) && t < last) {
+      skipped.push({ date, mtime, lastApplied: next[date] });
+      continue;
+    }
+    fresh[date] = note;
+    evidence[date] = mtime;
+    next[date] = mtime;
+  }
+  // Evidence for notes the gate did not judge (scoped notes keyed by path,
+  // dates not in this observation) passes through untouched.
+  for (const [key, iso] of Object.entries(noteMtimes || {})) {
+    if (!(key in (dailyNotes || {}))) evidence[key] = iso;
+  }
+  return { fresh, evidence, skipped, next };
+}
+
+/**
+ * The gate as the sync hook uses it: read the memory, judge, persist, log.
+ * @returns {{dailyNotes: object, noteMtimes: object, skipped: Array}}
+ */
+export function applyLateObservationGate(dailyNotes, noteMtimes, storage = defaultStorage()) {
+  const { fresh, evidence, skipped, next } = gateLateObservations(dailyNotes, noteMtimes, readLastAppliedMtimes(storage));
+  writeLastAppliedMtimes(next, storage);
+  if (skipped.length) {
+    console.info('[Obsidian] late observation skipped (older than the last applied mtime, spec 2.7):',
+      skipped.map((s) => `${s.date} ${s.mtime} < ${s.lastApplied}`).join('; '));
+  }
+  return { dailyNotes: fresh, noteMtimes: evidence, skipped };
+}

--- a/src/utils/lateObservationGate.test.js
+++ b/src/utils/lateObservationGate.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  gateLateObservations, applyLateObservationGate, readLastAppliedMtimes,
+  LAST_APPLIED_MTIME_KEY, LAST_APPLIED_RETAIN_DAYS,
+} from './lateObservationGate.js';
+
+const T0 = '2026-09-08T10:00:00.000Z';
+const T1 = '2026-09-08T11:00:00.000Z';
+const T2 = '2026-09-08T12:00:00.000Z';
+const NOW = Date.parse('2026-09-09T00:00:00.000Z');
+
+function storage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => { m.set(k, String(v)); },
+    removeItem: (k) => { m.delete(k); },
+  };
+}
+
+describe('gateLateObservations (spec 2.7, newest mtime wins for text)', () => {
+  it('an observation strictly older than the last applied mtime is skipped, text and evidence both', () => {
+    const r = gateLateObservations(
+      { '2026-09-08': { text: 'stale', lastModified: T0 } },
+      { '2026-09-08': T0 },
+      { '2026-09-08': T1 },
+      { now: NOW },
+    );
+    expect(r.fresh).toEqual({});
+    expect(r.evidence).toEqual({});
+    expect(r.skipped).toEqual([{ date: '2026-09-08', mtime: T0, lastApplied: T1 }]);
+    expect(r.next).toEqual({ '2026-09-08': T1 }); // memory unchanged by a skip
+  });
+
+  it('equal applies (idempotent re-observation) and newer applies and advances the memory', () => {
+    const equal = gateLateObservations({ d: { text: 'same' } }, { d: T1 }, { d: T1 }, { now: NOW });
+    expect(equal.fresh).toEqual({ d: { text: 'same' } });
+    expect(equal.skipped).toEqual([]);
+    const newer = gateLateObservations({ d: { text: 'new' } }, { d: T2 }, { d: T1 }, { now: NOW });
+    expect(newer.fresh).toEqual({ d: { text: 'new' } });
+    expect(newer.evidence).toEqual({ d: T2 });
+    expect(newer.next).toEqual({ d: T2 });
+  });
+
+  it('a first observation of a date always applies and is remembered', () => {
+    const r = gateLateObservations({ d: { text: 'first' } }, { d: T0 }, {}, { now: NOW });
+    expect(r.fresh).toEqual({ d: { text: 'first' } });
+    expect(r.next).toEqual({ d: T0 });
+  });
+
+  it('an observation without a real mtime applies and neither reads nor writes the memory', () => {
+    const r = gateLateObservations({ d: { text: 'no evidence' } }, {}, { d: T2 }, { now: NOW });
+    expect(r.fresh).toEqual({ d: { text: 'no evidence' } });
+    expect(r.evidence).toEqual({});
+    expect(r.next).toEqual({ d: T2 });
+  });
+
+  it('evidence for notes the gate did not judge passes through (scoped notes keyed by path)', () => {
+    const r = gateLateObservations({ d: { text: 'x' } }, { d: T1, 'Projects/House.md': T2 }, {}, { now: NOW });
+    expect(r.evidence).toEqual({ d: T1, 'Projects/House.md': T2 });
+  });
+
+  it('memory for dates older than the retention window falls out', () => {
+    const old = new Date(NOW - (LAST_APPLIED_RETAIN_DAYS + 1) * 86400000).toISOString().slice(0, 10);
+    const r = gateLateObservations({}, {}, { [old]: T0, '2026-09-01': T0 }, { now: NOW });
+    expect(r.next).toEqual({ '2026-09-01': T0 });
+  });
+});
+
+describe('applyLateObservationGate (storage round trip and the console line)', () => {
+  it('persists the memory, skips a late observation on the next call, and logs it', () => {
+    const s = storage();
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const first = applyLateObservationGate({ d: { text: 'v1' } }, { d: T1 }, s);
+    expect(first.dailyNotes).toEqual({ d: { text: 'v1' } });
+    expect(readLastAppliedMtimes(s)).toEqual({ d: T1 });
+    const late = applyLateObservationGate({ d: { text: 'v0' } }, { d: T0 }, s);
+    expect(late.dailyNotes).toEqual({});
+    expect(late.skipped).toHaveLength(1);
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('late observation skipped'), expect.stringContaining('d '));
+    info.mockRestore();
+  });
+
+  it('with no storage at all the gate degrades to always apply', () => {
+    const r = applyLateObservationGate({ d: { text: 'x' } }, { d: T0 }, null);
+    expect(r.dailyNotes).toEqual({ d: { text: 'x' } });
+  });
+
+  it('an unreadable memory value reads as empty', () => {
+    const s = storage();
+    s.setItem(LAST_APPLIED_MTIME_KEY, '{nope');
+    expect(readLastAppliedMtimes(s)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Closes the open question from the 2026-09-08 ping-pong record (spec 2.7). Owner ruling, 2026-09-09, Option B: an observation of a daily note whose real mtime is strictly older than the mtime of the last observation this device applied for that date is stale evidence and is dropped, text and revival evidence both. Equal or newer applies as before. An observation with no real mtime carries no evidence either way and always applies, as it always did.

This extends the existing rule that a note's mtime is the vault's statement time (section 3.10 ruling 6, existence) to the note's text.

## Changes

- `src/utils/lateObservationGate.js`: the pure gate (`gateLateObservations`) and the storage round trip (`applyLateObservationGate`). Memory is device-local under `dayglance-obsidian-last-applied-mtime`, never synced; dates older than 400 days fall out. A skip logs one console line naming the date and both mtimes.
- `src/hooks/useObsidianSync.js`: the gate runs before both daily-note merges, the bridge stream path and this device's own scan, so a lagging local copy is treated the same as a late stream row. The task merges receive the evidence map without the dropped dates.
- No change to any tier's merge, to what the plugin stamps or reports, or to the equal-stamp rule from #1575, which stays as the second line of defence.

## Verification

- `lateObservationGate.test.js`: strictly older skipped, equal and newer apply, first observation remembered, no mtime applies without touching memory, scoped-note evidence passes through, retention pruning, storage round trip with the console line, degraded mode without storage.
- Harness scenario 21: a real plugin report of a daily note under an mtime older than the last applied one leaves the app's newer text in place and logs the skip; a genuinely newer edit afterwards still applies.
- Full suite green, lint clean.

## Accepted edge

A note put back to an older version by a tool that preserves the old mtime is not seen until its next edit. Obsidian's own writes and restores set a fresh mtime. Recorded in spec 2.7 with the options considered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw1vPtxQLifCkbM7zC3vhQ)_