### PR TITLE
Day Dial: overlapping blocks ride concentric lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ An ambient, fullscreen view of the day as a 24-hour instrument dial — midnight
 
 ![The Day Dial](screenshots/day-dial.png)
 
+Overlapping blocks — a session nested inside an all-day conference, or a genuine double-booking — split onto concentric lanes instead of painting over each other, with the more specific block taking the outer edge. Lanes are scoped to each pile-up, so a clean afternoon keeps its wedges at the ring's full depth.
+
 If a weather location is set, hairlines mark sunrise (amber, with a sun glyph) and sunset (moonlight blue, with a moon glyph) — computed locally from your coordinates, so they work for any date and offline. On days the forecast covers, hour temperatures appear at the 3-hour marks and rain or snow spells are traced as a thin arc along the ring's inner edge. The Layers button in the corner toggles the solar marks, the weather ring, and imported calendar events; choices persist per device.
 
 For a wall display or kiosk, append `?dial` to the URL to boot straight into it — for example `http://localhost:6767/?dial` on a self-hosted Docker instance, or a pinned PWA on a wall tablet. The dial is built to run unattended: it follows the date across midnight, the cursor and corner buttons fade after a few seconds of stillness, and a browsed date snaps back to today after five idle minutes.

--- a/src/components/DayDial.jsx
+++ b/src/components/DayDial.jsx
@@ -9,6 +9,7 @@ import {
   computeDialModel,
   dialArcPath,
   dialIntensity,
+  dialLaneBand,
   dialPoint,
   dialSectorPath,
   dialTicks,
@@ -96,11 +97,14 @@ function TickField() {
   );
 }
 
-function Segment({ startMin, endMin, color, mute = 1, padStart = true, padEnd = true, onEnter, onLeave, onTap }) {
+function Segment({
+  startMin, endMin, color, mute = 1, padStart = true, padEnd = true,
+  rInner = R_INNER, rOuter = R_EDGE, onEnter, onLeave, onTap,
+}) {
   const [s, e] = padDialSegment(startMin, endMin, 3, padStart, padEnd);
   if (e <= s) return null;
   const { fillOpacity, edgeOpacity, edgeWidth } = dialIntensity(endMin - startMin);
-  const edge = dialArcPath(CX, CY, R_EDGE, s, e);
+  const edge = dialArcPath(CX, CY, rOuter, s, e);
   return (
     <g
       onMouseEnter={onEnter}
@@ -109,7 +113,7 @@ function Segment({ startMin, endMin, color, mute = 1, padStart = true, padEnd = 
       style={onTap ? { cursor: 'pointer' } : undefined}
     >
       <path
-        d={dialSectorPath(CX, CY, R_INNER, R_EDGE, s, e)}
+        d={dialSectorPath(CX, CY, rInner, rOuter, s, e)}
         fill={color}
         fillOpacity={fillOpacity * mute}
       />
@@ -331,6 +335,14 @@ const DayDial = ({ dayTasks, dayWindow, date, nowMin = null, dayIsPast = false, 
     [dayTasks, dayWindow],
   );
 
+  // Paint inner lanes first: the glow filter spreads past a lane's own band,
+  // so the outermost (most specific — see assignDialLanes) wedge has to lay
+  // its crisp edge down last.
+  const laneOrdered = useMemo(
+    () => [...model.blocks].sort((a, b) => a.lane - b.lane),
+    [model.blocks],
+  );
+
   const focus = nowMin !== null ? findDialFocusBlock(model.blocks, nowMin) : null;
 
   // Block inspection: hover or tap a wedge and the hub becomes its readout,
@@ -522,18 +534,25 @@ const DayDial = ({ dayTasks, dayWindow, date, nowMin = null, dayIsPast = false, 
           {/* Schedule blocks — each in its task's own hue, spoken in the
               dial's voice (muteDialColor pins every color into one
               pastel-emissive family). Completed and fully-past blocks stay
-              (the hour is spent) but recede to the dim tier. */}
-          {model.blocks.map((b) => (
-            <Segment
-              key={b.id}
-              startMin={b.startMin} endMin={b.endMin}
-              color={muteDialColor(b.colorHex)}
-              mute={b.completed || isPast(b.endMin) ? PAST_MUTE : 1}
-              onEnter={() => inspectEnter(b)}
-              onLeave={inspectLeave}
-              onTap={() => inspectTap(b)}
-            />
-          ))}
+              (the hour is spent) but recede to the dim tier. Overlapping
+              blocks ride concentric lanes (assignDialLanes) instead of
+              painting over each other; an unstacked day still fills the
+              whole band. */}
+          {laneOrdered.map((b) => {
+            const band = dialLaneBand(R_INNER, R_EDGE, b.lane, b.laneCount);
+            return (
+              <Segment
+                key={b.id}
+                startMin={b.startMin} endMin={b.endMin}
+                rInner={band.rInner} rOuter={band.rOuter}
+                color={muteDialColor(b.colorHex)}
+                mute={b.completed || isPast(b.endMin) ? PAST_MUTE : 1}
+                onEnter={() => inspectEnter(b)}
+                onLeave={inspectLeave}
+                onTap={() => inspectTap(b)}
+              />
+            );
+          })}
 
           {nowMin !== null && <NowLine nowMin={nowMin} />}
         </svg>

--- a/src/utils/dayDial.js
+++ b/src/utils/dayDial.js
@@ -117,13 +117,84 @@ export function padDialSegment(startMin, endMin, gapMin = 3, padStart = true, pa
 }
 
 /**
+ * Split overlapping blocks onto concentric lanes so a double-booked hour
+ * stops overdrawing itself. Classic interval partitioning, but scoped to
+ * each CLUSTER of transitively-overlapping blocks rather than the whole
+ * day: one double-booking at breakfast must not thin the ring for a clean
+ * afternoon, and a day with no overlaps (the common one) keeps every wedge
+ * at the band's full depth exactly as before.
+ *
+ * Lane 0 is innermost. Greedy assignment by start time therefore puts the
+ * earliest, longest block deepest and pushes each newcomer outward, which
+ * is the reading we want: a block nested inside a container ends up on the
+ * outer luminous rim — the same "nested wins" rule the hub already follows
+ * (findDialFocusBlock).
+ *
+ * Blocks that merely touch (one ends where the next starts) do not overlap;
+ * padDialSegment's gap already separates those along the ring.
+ *
+ * @param blocks Ring blocks sorted by startMin (computeDialModel's order).
+ * @returns New block objects carrying {lane, laneCount}, in the same order.
+ */
+export function assignDialLanes(blocks) {
+  const out = [];
+  let cluster = [];
+  let clusterEnd = -Infinity;
+  let laneEnds = [];
+
+  // One cluster's lane count applies to every block in it, so a wedge keeps
+  // the same depth for as long as the pile-up lasts instead of stepping
+  // radially mid-cluster.
+  const flush = () => {
+    for (const b of cluster) out.push({ ...b, laneCount: laneEnds.length });
+    cluster = [];
+    laneEnds = [];
+  };
+
+  for (const b of blocks || []) {
+    if (b.startMin >= clusterEnd) {
+      flush();
+      clusterEnd = b.endMin;
+    } else {
+      clusterEnd = Math.max(clusterEnd, b.endMin);
+    }
+    let lane = laneEnds.findIndex((end) => end <= b.startMin);
+    if (lane === -1) lane = laneEnds.length;
+    laneEnds[lane] = b.endMin;
+    cluster.push({ ...b, lane });
+  }
+  flush();
+  return out;
+}
+
+// Radial breathing room between lanes, in viewBox units. Yields on crowded
+// clusters (same principle as padDialSegment's gap) so four-deep overlaps
+// still leave each lane thick enough to carry its luminous edge.
+export const DIAL_LANE_GAP = 6;
+
+/**
+ * The radial band one lane occupies inside the schedule ring. A single lane
+ * takes the whole band, so the unstacked day is byte-identical to what the
+ * dial drew before lanes existed.
+ */
+export function dialLaneBand(rInner, rOuter, lane = 0, laneCount = 1) {
+  if (!(laneCount > 1)) return { rInner, rOuter };
+  const span = rOuter - rInner;
+  const gap = Math.min(DIAL_LANE_GAP, span / (laneCount * 5));
+  const depth = (span - gap * (laneCount - 1)) / laneCount;
+  const base = rInner + lane * (depth + gap);
+  return { rInner: fmt(base), rOuter: fmt(base + depth) };
+}
+
+/**
  * Roll one day's tasks + declared day window into everything the dial draws.
  *
  * @param dayTasks  The date's tasks (the getTasksForDate shape). Same scope
  *                  rules as computeDaySummary: only timed blocks count.
  * @param dayWindow Resolved {start, stop} 'HH:MM' markers or null.
  * @returns {{
- *   blocks: Array<{id, title, startMin, endMin, kind: 'effort'|'restore', completed: boolean}>,
+ *   blocks: Array<{id, title, startMin, endMin, kind: 'effort'|'restore',
+ *                  completed: boolean, lane: number, laneCount: number}>,
  *   sleep: Array<{startMin, endMin}>,   // outside the day window; empty without full markers
  *   effortMinutes: number,
  *   restoreMinutes: number,
@@ -132,7 +203,7 @@ export function padDialSegment(startMin, endMin, gapMin = 3, padStart = true, pa
  * }}
  */
 export function computeDialModel(dayTasks, dayWindow = null) {
-  const blocks = (dayTasks || [])
+  const blocks = assignDialLanes((dayTasks || [])
     .filter((t) => t && !t.isAllDay && t.startTime && (t.duration || 0) > 0)
     .map((t) => {
       const startMin = timeToMin(t.startTime);
@@ -152,7 +223,7 @@ export function computeDialModel(dayTasks, dayWindow = null) {
       };
     })
     .filter((b) => b.endMin > b.startMin)
-    .sort((a, b) => a.startMin - b.startMin || a.endMin - b.endMin);
+    .sort((a, b) => a.startMin - b.startMin || a.endMin - b.endMin));
 
   const startM = dayWindow?.start ? timeToMin(dayWindow.start) : null;
   const stopM = dayWindow?.stop ? timeToMin(dayWindow.stop) : null;

--- a/src/utils/dayDial.test.js
+++ b/src/utils/dayDial.test.js
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   DIAL_DAY_MINUTES,
+  DIAL_LANE_GAP,
+  assignDialLanes,
+  dialLaneBand,
   dialAngle,
   dialPoint,
   dialArcPath,
@@ -111,6 +114,77 @@ describe('padDialSegment', () => {
   });
 });
 
+describe('assignDialLanes', () => {
+  const blk = (startMin, endMin, id = `${startMin}`) => ({ id, startMin, endMin });
+
+  it('keeps a day with no overlaps on one full-depth lane', () => {
+    // Back-to-back blocks touch but never overlap — that separation is
+    // padDialSegment's job along the ring, not a lane's.
+    const laid = assignDialLanes([blk(540, 600), blk(600, 660), blk(700, 760)]);
+    expect(laid.map((b) => [b.lane, b.laneCount])).toEqual([[0, 1], [0, 1], [0, 1]]);
+  });
+
+  it('pushes a nested block onto the outer lane', () => {
+    // An all-day conference with a keynote inside it: the specific block
+    // takes the luminous rim, the container recedes inward.
+    const laid = assignDialLanes([blk(540, 1020, 'conf'), blk(570, 630, 'keynote')]);
+    expect(laid).toMatchObject([
+      { id: 'conf', lane: 0, laneCount: 2 },
+      { id: 'keynote', lane: 1, laneCount: 2 },
+    ]);
+  });
+
+  it('reuses a lane that has freed up inside the same cluster', () => {
+    const laid = assignDialLanes([blk(600, 660, 'a'), blk(630, 720, 'b'), blk(675, 720, 'c')]);
+    expect(laid.map((b) => b.lane)).toEqual([0, 1, 0]);
+    expect(laid.map((b) => b.laneCount)).toEqual([2, 2, 2]);
+  });
+
+  it('scopes the lane count to each overlap cluster', () => {
+    const laid = assignDialLanes([
+      blk(480, 540, 'morning'),
+      blk(600, 700, 'x'), blk(620, 720, 'y'), blk(640, 700, 'z'),
+      blk(800, 860, 'evening'),
+    ]);
+    // One three-deep pile-up must not thin the wedges around it.
+    expect(laid.map((b) => [b.id, b.lane, b.laneCount])).toEqual([
+      ['morning', 0, 1],
+      ['x', 0, 3], ['y', 1, 3], ['z', 2, 3],
+      ['evening', 0, 1],
+    ]);
+  });
+
+  it('handles empty and missing input', () => {
+    expect(assignDialLanes([])).toEqual([]);
+    expect(assignDialLanes(null)).toEqual([]);
+  });
+});
+
+describe('dialLaneBand', () => {
+  it('gives a single lane the whole band', () => {
+    expect(dialLaneBand(300, 385, 0, 1)).toEqual({ rInner: 300, rOuter: 385 });
+    expect(dialLaneBand(300, 385)).toEqual({ rInner: 300, rOuter: 385 });
+  });
+
+  it('splits the band inside-out, lane 0 innermost', () => {
+    const inner = dialLaneBand(300, 385, 0, 2);
+    const outer = dialLaneBand(300, 385, 1, 2);
+    expect(inner.rInner).toBe(300);
+    expect(outer.rOuter).toBe(385);
+    expect(outer.rInner - inner.rOuter).toBeCloseTo(DIAL_LANE_GAP);
+    expect(inner.rOuter - inner.rInner).toBeCloseTo(outer.rOuter - outer.rInner);
+  });
+
+  it('yields the gap so a crowded cluster keeps usable depth', () => {
+    const lanes = [0, 1, 2, 3, 4, 5].map((i) => dialLaneBand(300, 385, i, 6));
+    expect(lanes[0].rInner).toBe(300);
+    expect(lanes[5].rOuter).toBeCloseTo(385);
+    expect(lanes[1].rInner - lanes[0].rOuter).toBeLessThan(DIAL_LANE_GAP);
+    // Still thicker than the widest luminous edge (4) plus its halo.
+    lanes.forEach((l) => expect(l.rOuter - l.rInner).toBeGreaterThan(10));
+  });
+});
+
 describe('computeDialModel', () => {
   it('maps timed tasks to categorized ring blocks, sorted by start', () => {
     const model = computeDialModel([
@@ -168,6 +242,17 @@ describe('computeDialModel', () => {
     );
     // 08:00–12:00 window, 2h blocked → 2h unblocked.
     expect(model.unblockedMinutes).toBe(120);
+  });
+
+  it('lanes overlapping blocks and leaves a clean day at full depth', () => {
+    const model = computeDialModel([
+      task({ id: 1, title: 'Offsite', startTime: '09:00', duration: 480 }),
+      task({ id: 2, title: 'Keynote', startTime: '09:30', duration: 60 }),
+      task({ id: 3, title: 'Dinner', startTime: '18:00', duration: 60 }),
+    ]);
+    expect(model.blocks.map((b) => [b.id, b.lane, b.laneCount])).toEqual([
+      [1, 0, 2], [2, 1, 2], [3, 0, 1],
+    ]);
   });
 
   it('handles an empty day', () => {


### PR DESCRIPTION
## What changed

Overlapping schedule blocks on the Day Dial were all drawn at the same radial band (`R_INNER..R_EDGE`), so a session nested inside an all-day conference — or a genuine double-booking — painted straight over its neighbour: the covered block was invisible and unreachable (the top-drawn wedge also took its hit area).

Blocks now ride concentric lanes:

- **`assignDialLanes(blocks)`** (`src/utils/dayDial.js`) — classic interval partitioning, scoped to each *cluster* of transitively-overlapping blocks rather than the whole day. One pile-up at breakfast no longer thins the ring for a clean afternoon, and a day with no overlaps keeps every wedge at the band's full depth. Lane 0 is innermost, so greedy assignment by start time puts the container deepest and lifts the nested block onto the outer luminous rim — the same "nested wins" reading `findDialFocusBlock` already gives the hub. Blocks that merely touch don't overlap; `padDialSegment`'s gap still separates those along the ring.
- **`dialLaneBand(rInner, rOuter, lane, laneCount)`** — the radial sub-band for one lane, with a gap that yields as the cluster deepens (a six-deep stack still leaves each lane ~12 viewBox units, thick enough to carry its own edge and halo). A single lane returns the whole band unchanged.
- **`computeDialModel`** feeds its sorted blocks through the assignment, so each block carries `lane` and `laneCount`.
- **`DayDial.jsx`** — `Segment` takes `rInner`/`rOuter` as props (defaulting to the full ring, so the sleep layer is untouched), and the block layer paints inner lanes first so an outer lane's crisp edge never lands under its neighbour's glow.

## Why

Overlap was the one case where the dial lied about the day: a double-booked hour looked like a single block. Lanes are the minimum honest representation, and scoping them per cluster keeps the common, unstacked day pixel-for-pixel as it was.

## Testing

- 9 new cases in `src/utils/dayDial.test.js` cover nested-block lane order, lane reuse inside a cluster, per-cluster lane counts, empty/missing input, and the band geometry (inside-out split, gap yielding, minimum usable depth). `dayDial.test.js`: 38 passing.
- Full suite: 249 files / 3347 tests passing; ESLint clean.
- Rendered the real geometry headlessly for a messy day (nested container + partial double-booking + clean blocks) and for a six-deep stress case to confirm each lane keeps a legible rim and the gaps read cleanly at ambient distance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lj8Pw3MBmbEvYPSWLSHnPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj8Pw3MBmbEvYPSWLSHnPS)_