### PR TITLE
Day Dial: keyboard and screen-reader access to the ring

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ An ambient, fullscreen view of the day as a 24-hour instrument dial — midnight
 
 Overlapping blocks — a session nested inside an all-day conference, or a genuine double-booking — split onto concentric lanes instead of painting over each other, with the more specific block taking the outer edge. Lanes are scoped to each pile-up, so a clean afternoon keeps its wedges at the ring's full depth.
 
+Everything on the ring is reachable from the keyboard: Tab into the dial and the block running now lights up and reads out in the hub, `↑`/`↓` walk the day's blocks (`Home`/`End` for the first and last), `Enter` opens that block's actions — mark complete, open in planner — and `Esc` steps back out. Screen readers get the ring as a labelled list, each block announcing its title, time range, duration, and how long until it starts or ends.
+
 If a weather location is set, hairlines mark sunrise (amber, with a sun glyph) and sunset (moonlight blue, with a moon glyph) — computed locally from your coordinates, so they work for any date and offline. On days the forecast covers, hour temperatures appear at the 3-hour marks and rain or snow spells are traced as a thin arc along the ring's inner edge. The Layers button in the corner toggles the solar marks, the weather ring, and imported calendar events; choices persist per device.
 
 For a wall display or kiosk, append `?dial` to the URL to boot straight into it — for example `http://localhost:6767/?dial` on a self-hosted Docker instance, or a pinned PWA on a wall tablet. The dial is built to run unattended: it follows the date across midnight, the cursor and corner buttons fade after a few seconds of stillness, and a browsed date snaps back to today after five idle minutes.

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -1334,6 +1334,7 @@
     "sleep": "Schlaf",
     "unblocked": "Ungeplant",
     "aria": "Tagesanzeige: {{date}}",
+    "blockList": "Terminblöcke",
     "backToToday": "Zurück zu heute (T)",
     "today": "Heute",
     "prevDay": "Vorheriger Tag (←)",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1334,6 +1334,7 @@
     "sleep": "Sleep",
     "unblocked": "Unblocked",
     "aria": "Day dial: {{date}}",
+    "blockList": "Schedule blocks",
     "backToToday": "Back to today (T)",
     "today": "Today",
     "prevDay": "Previous day (←)",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1334,6 +1334,7 @@
     "sleep": "Sueño",
     "unblocked": "Tiempo libre",
     "aria": "Esfera del día: {{date}}",
+    "blockList": "Bloques de la agenda",
     "backToToday": "Volver a hoy (T)",
     "today": "Hoy",
     "prevDay": "Día anterior (←)",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1334,6 +1334,7 @@
     "sleep": "Sommeil",
     "unblocked": "Temps libre",
     "aria": "Cadran du jour : {{date}}",
+    "blockList": "Blocs de la journée",
     "backToToday": "Revenir à aujourd'hui (T)",
     "today": "Aujourd'hui",
     "prevDay": "Jour précédent (←)",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -1334,6 +1334,7 @@
     "sleep": "Sonno",
     "unblocked": "Tempo libero",
     "aria": "Quadrante del giorno: {{date}}",
+    "blockList": "Blocchi della giornata",
     "backToToday": "Torna a oggi (T)",
     "today": "Oggi",
     "prevDay": "Giorno precedente (←)",

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -1334,6 +1334,7 @@
     "sleep": "Sono",
     "unblocked": "Tempo livre",
     "aria": "Mostrador do dia: {{date}}",
+    "blockList": "Blocos da agenda",
     "backToToday": "Voltar para hoje (T)",
     "today": "Hoje",
     "prevDay": "Dia anterior (←)",

--- a/public/locales/pt-PT/translation.json
+++ b/public/locales/pt-PT/translation.json
@@ -1334,6 +1334,7 @@
     "sleep": "Sono",
     "unblocked": "Tempo livre",
     "aria": "Mostrador do dia: {{date}}",
+    "blockList": "Blocos da agenda",
     "backToToday": "Voltar a hoje (T)",
     "today": "Hoje",
     "prevDay": "Dia anterior (←)",

--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -1334,6 +1334,7 @@
     "sleep": "睡眠",
     "unblocked": "可用时间",
     "aria": "日程表盘：{{date}}",
+    "blockList": "日程时段",
     "backToToday": "返回今天 (T)",
     "today": "今天",
     "prevDay": "前一天 (←)",

--- a/src/components/DayDial.a11y.test.jsx
+++ b/src/components/DayDial.a11y.test.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import i18next from 'i18next';
+import { I18nextProvider } from 'react-i18next';
+import { loaders } from '../locales.js';
+import DayDial from './DayDial.jsx';
+
+// The ring's accessibility contract. The wedges are inside an SVG that AT
+// reads as one image, so the blocks carry their semantics in a parallel
+// listbox (see DayDial.jsx) — this pins that markup down: one option per
+// block, in time order, each with the id aria-activedescendant will name and
+// a label that says everything the hub would.
+//
+// Static markup, not a DOM: this repo has no jsdom (same approach as
+// GlanceLocalization.test.jsx), so the keyboard MOVES are tested as pure
+// functions in utils/dayDial.test.js and the wiring they move through is
+// tested here.
+
+async function i18nFor(language) {
+  const bundle = await loaders[language]();
+  const i18n = i18next.createInstance();
+  await i18n.init({
+    lng: language, fallbackLng: false,
+    resources: { [language]: { translation: bundle } },
+    interpolation: { escapeValue: false },
+  });
+  return i18n;
+}
+
+const task = (over = {}) => ({
+  id: 1, title: 'Deep work', startTime: '09:00', duration: 60,
+  isAllDay: false, completed: false, ...over,
+});
+
+const render = (i18n, props = {}) => renderToStaticMarkup(
+  <I18nextProvider i18n={i18n}>
+    <DayDial
+      dayTasks={[]}
+      dayWindow={null}
+      date={new Date('2026-09-09T12:00:00')}
+      nowMin={9 * 60 + 30}
+      formatTime={(hhmm) => hhmm}
+      use24HourClock
+      {...props}
+    />
+  </I18nextProvider>,
+);
+
+// <div role="option" id="…" aria-selected="…">label</div>, in document order.
+const options = (html) => Array.from(
+  html.matchAll(/<div id="([^"]*)" role="option" aria-selected="([^"]*)" class="sr-only">([^<]*)</g),
+).map(([, id, selected, label]) => ({ id, selected, label }));
+
+describe('DayDial keyboard/AT contract', () => {
+  it('exposes one labelled option per block, in time order', async () => {
+    const i18n = await i18nFor('en');
+    const html = render(i18n, {
+      dayTasks: [
+        task({ id: 2, title: 'Team sync', startTime: '14:00', duration: 30 }),
+        task({ id: 1, title: 'Deep work #focus', startTime: '09:00', duration: 90 }),
+      ],
+    });
+    expect(options(html)).toEqual([
+      { id: 'dial-opt-1', selected: 'false', label: 'Deep work #focus, 09:00 – 10:30, 1h 30m, 1h left' },
+      { id: 'dial-opt-2', selected: 'false', label: 'Team sync, 14:00 – 14:30, 30m, in 4h 30m' },
+    ]);
+  });
+
+  it('gives the ring one tab stop, named and empty-aware', async () => {
+    const i18n = await i18nFor('en');
+    const withBlocks = render(i18n, { dayTasks: [task()] });
+    expect(withBlocks).toContain('role="listbox"');
+    expect(withBlocks).toContain('aria-label="Schedule blocks"');
+    expect(withBlocks).toContain('tabindex="0"');
+    // Nothing to select yet, so no dangling aria-activedescendant.
+    expect(withBlocks).not.toContain('aria-activedescendant');
+
+    // A day with no timed blocks is not a tab stop at all.
+    const empty = render(i18n, { dayTasks: [task({ isAllDay: true })] });
+    expect(empty).toContain('tabindex="-1"');
+    expect(options(empty)).toEqual([]);
+  });
+
+  it('says "completed" instead of the clock for a finished block', async () => {
+    const i18n = await i18nFor('en');
+    const html = render(i18n, { dayTasks: [task({ completed: true })] });
+    expect(options(html)[0].label).toBe('Deep work, 09:00 – 10:00, 1h, completed');
+  });
+
+  it('drops the relative phrase on a day with no now line', async () => {
+    const i18n = await i18nFor('en');
+    const html = render(i18n, { dayTasks: [task()], nowMin: null, dayIsPast: true });
+    expect(options(html)[0].label).toBe('Deep work, 09:00 – 10:00, 1h');
+  });
+
+  it('keeps option ids usable for any task id', async () => {
+    const i18n = await i18nFor('en');
+    // Recurring instances carry separators, and a title-derived id could
+    // carry spaces — an HTML id tolerates everything but whitespace.
+    const html = render(i18n, {
+      dayTasks: [task({ id: 'recur-7::2026-09-09' }), task({ id: 'has space', startTime: '11:00' })],
+    });
+    expect(options(html).map((o) => o.id)).toEqual([
+      'dial-opt-recur-7::2026-09-09',
+      'dial-opt-has_space',
+    ]);
+  });
+
+  it('localizes the listbox name and the option labels', async () => {
+    const i18n = await i18nFor('de');
+    const html = render(i18n, { dayTasks: [task({ completed: true })] });
+    expect(html).toContain(`aria-label="${i18n.t('dial.blockList')}"`);
+    expect(options(html)[0].label).toBe('Deep work, 09:00 – 10:00, 1h, erledigt');
+  });
+});

--- a/src/components/DayDial.jsx
+++ b/src/components/DayDial.jsx
@@ -15,9 +15,11 @@ import {
   dialTicks,
   dialLabelYieldsToSun,
   findDialFocusBlock,
+  initialDialSelection,
   muteDialColor,
   padDialSegment,
   precipRuns,
+  stepDialSelection,
 } from '../utils/dayDial.js';
 
 // The Day Dial: one day as a 24-hour instrument face. Midnight at top,
@@ -99,12 +101,19 @@ function TickField() {
 
 function Segment({
   startMin, endMin, color, mute = 1, padStart = true, padEnd = true,
-  rInner = R_INNER, rOuter = R_EDGE, onEnter, onLeave, onTap,
+  rInner = R_INNER, rOuter = R_EDGE, selected = false, onEnter, onLeave, onTap,
 }) {
   const [s, e] = padDialSegment(startMin, endMin, 3, padStart, padEnd);
   if (e <= s) return null;
   const { fillOpacity, edgeOpacity, edgeWidth } = dialIntensity(endMin - startMin);
   const edge = dialArcPath(CX, CY, rOuter, s, e);
+  // Selection — hover, tap, or the keyboard's roving selection — lights the
+  // wedge: full luminous edge plus a hairline tracing the whole sector, so
+  // a short block still reads as chosen. It overrides the dim tier too; a
+  // selected past block has to answer, and this doubles as the keyboard
+  // focus indicator (the listbox itself draws nothing).
+  const lit = selected ? 1 : mute;
+  const edgeAlpha = selected ? 1 : edgeOpacity;
   return (
     <g
       onMouseEnter={onEnter}
@@ -115,21 +124,27 @@ function Segment({
       <path
         d={dialSectorPath(CX, CY, rInner, rOuter, s, e)}
         fill={color}
-        fillOpacity={fillOpacity * mute}
+        fillOpacity={fillOpacity * lit}
       />
       {/* Soft halo under the crisp edge — one glowing rim reads better at
           distance than any texture. */}
       <path
         d={edge}
         fill="none" stroke={color} strokeLinecap="round"
-        strokeWidth={edgeWidth * 2.4} strokeOpacity={0.35 * edgeOpacity * mute}
+        strokeWidth={edgeWidth * 2.4} strokeOpacity={0.35 * edgeAlpha * lit}
         filter="url(#dial-glow)"
       />
       <path
         d={edge}
         fill="none" stroke={color} strokeLinecap="round"
-        strokeWidth={edgeWidth} strokeOpacity={edgeOpacity * mute}
+        strokeWidth={edgeWidth} strokeOpacity={edgeAlpha * lit}
       />
+      {selected && (
+        <path
+          d={dialSectorPath(CX, CY, rInner, rOuter, s, e)}
+          fill="none" stroke="#ffffff" strokeOpacity={0.45} strokeWidth={1.5}
+        />
+      )}
     </g>
   );
 }
@@ -368,7 +383,12 @@ const DayDial = ({ dayTasks, dayWindow, date, nowMin = null, dayIsPast = false, 
   // self-dismisses after a quiet while for the same reason.
   const [sheetBlock, setSheetBlock] = useState(null);
   const sheetTimerRef = useRef(null);
-  const openSheet = (b) => {
+  // Whether this sheet was opened from the keyboard — decides whether it
+  // takes focus on open and hands it back on close. A pointer user who
+  // never left the glass should not suddenly acquire a focused element.
+  const sheetFromKeyRef = useRef(false);
+  const openSheet = (b, fromKey = false) => {
+    sheetFromKeyRef.current = fromKey;
     setSheetBlock(b);
     clearTimeout(sheetTimerRef.current);
     sheetTimerRef.current = setTimeout(() => setSheetBlock(null), 20_000);
@@ -382,7 +402,106 @@ const DayDial = ({ dayTasks, dayWindow, date, nowMin = null, dayIsPast = false, 
     setInspected(b);
     scheduleInspectClear(4000);
   };
-  useEffect(() => { setInspected(null); setSheetBlock(null); }, [date]);
+
+  // Keyboard access to the ring. The wedges live inside an SVG that AT sees
+  // as a single image (role="img" prunes its descendants), and they were
+  // pointer-only — so completing a block from the keyboard was impossible.
+  // Rather than make each wedge a tab stop, the ring is ONE listbox with a
+  // roving selection: the same `inspected` state hover already drives, so
+  // the hub narrates it and the wedge lights up for free. Selection made
+  // this way is persistent — no dwell timer, unlike hover and tap.
+  const listRef = useRef(null);
+  const selectBlock = (b) => { if (b) inspectEnter(b); };
+  const clearSelection = () => { clearTimeout(inspectTimerRef.current); setInspected(null); };
+
+  // Live model + clock for effects that must not re-run on every minute
+  // tick (the ref is written during render, as App.jsx does for the dial's
+  // own open state).
+  const liveRef = useRef(null);
+  liveRef.current = { blocks: model.blocks, nowMin };
+
+  // Paging to another date drops the selection with it — but if the ring
+  // still holds focus, re-arm on the new day: a focused ring must never be
+  // left without its visible indicator.
+  useEffect(() => {
+    setSheetBlock(null);
+    const focused = typeof document !== 'undefined' && listRef.current === document.activeElement;
+    setInspected(focused ? initialDialSelection(liveRef.current.blocks, liveRef.current.nowMin) : null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [date]);
+
+  const onListKeyDown = (e) => {
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    const { blocks } = model;
+    const step = (delta) => selectBlock(stepDialSelection(blocks, inspected?.id ?? null, delta));
+    switch (e.key) {
+      // Up/down, not left/right: those page the day at the overlay level,
+      // and the schedule answers as the vertical list a listbox always is.
+      case 'ArrowDown': step(1); break;
+      case 'ArrowUp': step(-1); break;
+      case 'Home': step(-blocks.length); break;
+      case 'End': step(blocks.length); break;
+      case 'Enter':
+      case ' ':
+        if (!inspected) return;
+        openSheet(inspected, true);
+        break;
+      case 'Escape':
+        // Only our rung of the Escape ladder: with nothing selected the
+        // press belongs to the overlay (leave fullscreen, then close).
+        if (!inspected) return;
+        clearSelection();
+        break;
+      default: return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  // Tabbing in lands on the block the hub is already narrating, so there is
+  // always a visible indicator while the ring holds focus.
+  const onListFocus = (e) => {
+    if (e.target !== e.currentTarget) return;
+    if (!inspected) selectBlock(initialDialSelection(model.blocks, nowMin));
+  };
+  const onListBlur = (e) => {
+    // Focus moving into the action sheet is not leaving the ring — that
+    // selection is exactly what the sheet is about.
+    if (sheetBlock) return;
+    if (e.currentTarget.contains(e.relatedTarget)) return;
+    clearSelection();
+  };
+
+  // Keyboard flow through the sheet: focus its first action, trap Tab while
+  // it is up (capture phase, so focus can never wander to the chrome
+  // behind it), and hand focus back to the ring when it goes away —
+  // including when it self-dismisses on its own timer.
+  const sheetRef = useRef(null);
+  useEffect(() => {
+    if (!sheetBlock) return undefined;
+    // The listbox node is stable across renders; capture it so the cleanup
+    // does not read a ref that may have been detached by then.
+    const list = listRef.current;
+    const buttons = () => Array.from(sheetRef.current?.querySelectorAll('button') || []);
+    if (sheetFromKeyRef.current) buttons()[0]?.focus();
+    const onKeyDown = (e) => {
+      if (e.key !== 'Tab') return;
+      const items = buttons();
+      if (!items.length) return;
+      e.preventDefault();
+      const i = items.indexOf(document.activeElement);
+      const next = e.shiftKey
+        ? (i <= 0 ? items.length - 1 : i - 1)
+        : (i === -1 || i === items.length - 1 ? 0 : i + 1);
+      items[next]?.focus();
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      if (sheetFromKeyRef.current && list?.isConnected) list.focus();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sheetBlock]);
 
   // Esc closes the sheet before anything above it (capture phase, so the
   // overlay's own Escape-closes-the-dial handler never sees this press).
@@ -427,6 +546,21 @@ const DayDial = ({ dayTasks, dayWindow, date, nowMin = null, dayIsPast = false, 
 
   const minToHHMM = (m) =>
     `${String(Math.floor(m / 60)).padStart(2, '0')}:${String(m % 60).padStart(2, '0')}`;
+
+  // What a screen reader says for one block: the same facts the hub shows,
+  // as one sentence. Tags stay in (unlike the hub, which sets them aside
+  // typographically — there is no typography in an option label), and the
+  // commas give the reader its pauses.
+  const blockA11yLabel = (b) => [
+    stripWikilinks(b.title),
+    `${formatTime(minToHHMM(b.startMin))} – ${formatTime(minToHHMM(b.endMin))}`,
+    formatMinutes(b.endMin - b.startMin),
+    b.completed ? t('dial.completed', 'completed') : relLabel(b),
+  ].filter(Boolean).join(', ');
+
+  // Option ids must survive any task id (recurring instances carry
+  // separators); only whitespace is unusable in an HTML id.
+  const optionId = (id) => `dial-opt-${String(id).replace(/\s+/g, '_')}`;
 
   const weekday = date.toLocaleDateString(i18n.language, { weekday: 'long' });
   const dateLabel = date.toLocaleDateString(i18n.language, { month: 'long', day: 'numeric' });
@@ -547,6 +681,7 @@ const DayDial = ({ dayTasks, dayWindow, date, nowMin = null, dayIsPast = false, 
                 rInner={band.rInner} rOuter={band.rOuter}
                 color={muteDialColor(b.colorHex)}
                 mute={b.completed || isPast(b.endMin) ? PAST_MUTE : 1}
+                selected={inspected?.id === b.id}
                 onEnter={() => inspectEnter(b)}
                 onLeave={inspectLeave}
                 onTap={() => inspectTap(b)}
@@ -665,6 +800,36 @@ const DayDial = ({ dayTasks, dayWindow, date, nowMin = null, dayIsPast = false, 
           )}
         </div>
 
+        {/* The ring's accessibility tree and its single tab stop. The SVG
+            above is one image to AT, so the blocks get real semantics here:
+            a listbox of visually-hidden options, one per block in time
+            order, with aria-activedescendant naming the selected one. It
+            draws no pixels and swallows no pointer events — the lit wedge
+            and the hub readout are the visible half of this state. */}
+        <div
+          ref={listRef}
+          role="listbox"
+          tabIndex={model.blocks.length ? 0 : -1}
+          aria-label={t('dial.blockList', 'Schedule blocks')}
+          aria-activedescendant={inspected ? optionId(inspected.id) : undefined}
+          onKeyDown={onListKeyDown}
+          onFocus={onListFocus}
+          onBlur={onListBlur}
+          className="absolute inset-0 pointer-events-none outline-none"
+        >
+          {model.blocks.map((b) => (
+            <div
+              key={b.id}
+              id={optionId(b.id)}
+              role="option"
+              aria-selected={inspected?.id === b.id}
+              className="sr-only"
+            >
+              {blockA11yLabel(b)}
+            </div>
+          ))}
+        </div>
+
         {/* Action sheet — the dial's own register, never planner chrome.
             Backdrop click/tap dismisses; actions dismiss after acting. */}
         {sheetBlock && (() => {
@@ -676,7 +841,9 @@ const DayDial = ({ dayTasks, dayWindow, date, nowMin = null, dayIsPast = false, 
               onTouchEnd={(e) => e.stopPropagation()}
             >
               <div
+                ref={sheetRef}
                 role="dialog"
+                aria-modal="true"
                 aria-label={stripWikilinks(live.title)}
                 className="w-[min(82%,340px)] rounded-2xl border border-white/10 bg-[#12151c] px-5 py-4 shadow-2xl"
                 onClick={(e) => e.stopPropagation()}

--- a/src/components/DayDialModal.jsx
+++ b/src/components/DayDialModal.jsx
@@ -233,6 +233,13 @@ const DayDialModal = () => {
   // One activity clock for both idle behaviors. chromeVisible drives the
   // cursor and corner buttons; lastActiveRef drives the return-to-today
   // check, which rides the minute tick rather than owning a timer.
+  //
+  // focusin counts as activity: the corner buttons and the hub's day
+  // chevrons stay in the tab order while faded, so a Tab that lands on one
+  // — or the action sheet handing focus back to the ring — has to bring the
+  // chrome back rather than leave a focused control invisible. It cannot
+  // wake the display out of ambient (that needs a key, tap, or wheel on the
+  // shield), so a programmatic focus never ends a screensaver.
   const [chromeVisible, setChromeVisible] = useState(true);
   const lastActiveRef = useRef(Date.now());
   useEffect(() => {
@@ -244,7 +251,7 @@ const DayDialModal = () => {
       hideTimer = setTimeout(() => setChromeVisible(false), CHROME_HIDE_MS);
     };
     wake();
-    const events = ['pointermove', 'pointerdown', 'keydown', 'wheel'];
+    const events = ['pointermove', 'pointerdown', 'keydown', 'wheel', 'focusin'];
     events.forEach((ev) => document.addEventListener(ev, wake));
     return () => {
       clearTimeout(hideTimer);

--- a/src/utils/dayDial.js
+++ b/src/utils/dayDial.js
@@ -345,6 +345,44 @@ export function findDialFocusBlock(blocks, nowMin) {
   return next ? { block: next, current: false } : null;
 }
 
+/**
+ * Where a keyboard selection starts when focus first reaches the ring: the
+ * block the hub is already narrating, so tabbing in lands on "now" rather
+ * than on an arbitrary end of the day. Once today is spent (nothing running,
+ * nothing ahead) the last block is the useful entry — that is the hour just
+ * finished. Another date has no "now", so it starts at the top of the day.
+ *
+ * @returns The block to select, or null on a day with no timed blocks.
+ */
+export function initialDialSelection(blocks, nowMin = null) {
+  const list = blocks || [];
+  if (!list.length) return null;
+  if (nowMin === null) return list[0];
+  const focus = findDialFocusBlock(list, nowMin);
+  return focus ? focus.block : list[list.length - 1];
+}
+
+/**
+ * Move a keyboard selection through the day in time order. Clamps at both
+ * ends rather than wrapping — Home/End are the deliberate way to reach the
+ * extremes, and a selection that silently jumps from 23:00 back to 06:00
+ * loses the "walking forward through the day" reading. A selection that has
+ * gone stale (its block edited away) re-enters from the end the caller was
+ * heading toward.
+ *
+ * @param blocks    Ring blocks in computeDialModel order (by start time).
+ * @param currentId id of the selected block, or null for none.
+ * @param delta     Steps to move; negative walks back toward midnight.
+ * @returns The newly selected block, or null on a day with no blocks.
+ */
+export function stepDialSelection(blocks, currentId, delta) {
+  const list = blocks || [];
+  if (!list.length) return null;
+  const i = list.findIndex((b) => b.id === currentId);
+  if (i === -1) return delta < 0 ? list[list.length - 1] : list[0];
+  return list[Math.max(0, Math.min(list.length - 1, i + delta))];
+}
+
 // A sunrise/sunset mark rides its hairline out to the hour-label radius, so
 // a sun time within about half an hour of a label parks the glyph on the
 // text ("6☼AM" for an August sunrise at 6:09). The label yields for those

--- a/src/utils/dayDial.test.js
+++ b/src/utils/dayDial.test.js
@@ -15,8 +15,10 @@ import {
   computeDialModel,
   dialLabelYieldsToSun,
   findDialFocusBlock,
+  initialDialSelection,
   muteDialColor,
   precipRuns,
+  stepDialSelection,
 } from './dayDial.js';
 
 const task = (over = {}) => ({
@@ -340,6 +342,60 @@ describe('findDialFocusBlock', () => {
   it('returns null when the rest of the day is clear', () => {
     expect(findDialFocusBlock(blocks, 1000)).toBeNull();
     expect(findDialFocusBlock([], 600)).toBeNull();
+  });
+});
+
+describe('initialDialSelection / stepDialSelection', () => {
+  const blocks = [
+    { id: 'a', startMin: 540, endMin: 600 },
+    { id: 'b', startMin: 660, endMin: 720 },
+    { id: 'c', startMin: 900, endMin: 960 },
+  ];
+
+  it('starts a selection on the block the hub is narrating', () => {
+    // Mid-block, and between blocks (the next one up).
+    expect(initialDialSelection(blocks, 570).id).toBe('a');
+    expect(initialDialSelection(blocks, 630).id).toBe('b');
+  });
+
+  it('starts at the last block once the day is spent', () => {
+    expect(initialDialSelection(blocks, 1200).id).toBe('c');
+  });
+
+  it('starts at the top of the day on a date with no now line', () => {
+    expect(initialDialSelection(blocks, null).id).toBe('a');
+  });
+
+  it('has nothing to select on an empty day', () => {
+    expect(initialDialSelection([], 570)).toBeNull();
+    expect(initialDialSelection(null, null)).toBeNull();
+  });
+
+  it('walks the day in time order', () => {
+    expect(stepDialSelection(blocks, 'a', 1).id).toBe('b');
+    expect(stepDialSelection(blocks, 'c', -1).id).toBe('b');
+  });
+
+  it('clamps at both ends instead of wrapping', () => {
+    expect(stepDialSelection(blocks, 'c', 1).id).toBe('c');
+    expect(stepDialSelection(blocks, 'a', -1).id).toBe('a');
+  });
+
+  it('re-enters from the end the caller was heading toward', () => {
+    // Selection went stale — the block was edited away under it.
+    expect(stepDialSelection(blocks, 'gone', 1).id).toBe('a');
+    expect(stepDialSelection(blocks, 'gone', -1).id).toBe('c');
+    expect(stepDialSelection(blocks, null, 1).id).toBe('a');
+  });
+
+  it('reaches the extremes in one step (Home / End)', () => {
+    expect(stepDialSelection(blocks, 'b', -blocks.length).id).toBe('a');
+    expect(stepDialSelection(blocks, 'b', blocks.length).id).toBe('c');
+  });
+
+  it('has nothing to step through on an empty day', () => {
+    expect(stepDialSelection([], null, 1)).toBeNull();
+    expect(stepDialSelection(null, 'a', -1)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What changed

The dial's wedges were pointer-only: hover/click handlers on `<g>` elements inside an SVG that AT reads as a single image (`role="img"` prunes its descendants). So the blocks did not exist for a screen reader at all, and the action sheet could only be *opened* by pointer — mark-complete and open-in-planner were unreachable from the keyboard.

**The ring is now one listbox with a roving selection**, rather than a tab stop per wedge. A visually-hidden `role="option"` per block (in time order) sits in a focusable overlay over the dial, with `aria-activedescendant` naming the selected one. Each option reads as one sentence: title, time range, duration, and how long until it starts or ends — or "completed". The overlay draws no pixels and swallows no pointer events, because the selection is the same `inspected` state hover already drives, so the hub narrates it for free.

| key | action |
|---|---|
| `↑` / `↓` | previous / next block (left/right stay day paging) |
| `Home` / `End` | first / last block |
| `Enter` / `Space` | open that block's action sheet |
| `Esc` | clear the selection |

**Selection now lights its wedge** — full luminous edge plus a hairline tracing the sector, overriding the dim past tier. That is the keyboard's visible focus indicator, and it incidentally fixes hover having had no ring feedback whatsoever. Tabbing in selects the block the hub is already narrating (`initialDialSelection`: the running block, else the next, else the last on a spent day), and paging dates while focused re-arms on the new day, so a focused ring is never left without an indicator.

**The action sheet joins the flow:** it takes focus when opened from the keyboard (not when opened by pointer), traps Tab while up via a capture-phase handler, and hands focus back to the ring when it closes — including when it self-dismisses on its own 20s timer. The Escape ladder is now **sheet → selection → fullscreen → close dial**.

**`DayDialModal` counts `focusin` as activity**, so a Tab landing on faded chrome — or the sheet handing focus back — brings the chrome with it instead of leaving a focused control invisible. `focusin` deliberately cannot wake the display out of ambient, which still requires a key, tap, or wheel, so a programmatic focus never ends a screensaver.

## Why

Everything the dial can do from the couch was pointer-only, which made the ambient surface unusable with a keyboard and invisible to a screen reader. A listbox with a roving selection fits the dial's existing model exactly — the hub is already the readout — so this adds semantics and keys without putting any new chrome on the instrument face.

## Testing

- The navigation moves are pure functions (`initialDialSelection`, `stepDialSelection` in `src/utils/dayDial.js`) with 9 new cases in `src/utils/dayDial.test.js`: entry point per day state, clamping at both ends instead of wrapping, Home/End, stale selections, empty days.
- New `src/components/DayDial.a11y.test.jsx` pins the markup contract via `renderToStaticMarkup` (this repo has no jsdom; same approach as `GlanceLocalization.test.jsx`): one labelled option per block in time order, one tab stop that disappears on a day with no timed blocks, no dangling `aria-activedescendant`, "completed" vs. the relative clock, option ids that survive recurring-instance ids and whitespace, and the German bundle for the localized path.
- `dial.blockList` added to all 8 locale bundles.
- Full suite: 250 files / 3362 tests passing; ESLint clean.
- Rendered the selection treatment headlessly against the real geometry to confirm it reads as an instrument selection at ambient distance rather than foreign chrome.

## Note on the branch

The previous PR (#1591, the lane work) was merged while this was in progress, so this branch was restarted from the current `main` and carries only the keyboard change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lj8Pw3MBmbEvYPSWLSHnPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj8Pw3MBmbEvYPSWLSHnPS)_