### PR TITLE
Day Dial: mark 100% with a check instead of cramming the figure

### DIFF
--- a/src/components/DialComplications.jsx
+++ b/src/components/DialComplications.jsx
@@ -187,9 +187,20 @@ function DoneSlot({ item, size, onOpen, t }) {
             className="transition-all duration-500"
           />
         </svg>
-        <span className={`text-white/85 ${size.count} font-medium leading-none tabular-nums`}>
-          {pct}
-        </span>
+        {/* "100" is the one three-digit value, and it measures 50px inside a
+            53px ring — jammed against the stroke. It is also the only value
+            worth a mark rather than a number, and HabitRing already says
+            "goal met" with a check, so the face keeps one vocabulary. */}
+        {met ? (
+          <Check
+            size={Math.round(size.dot * 0.34)} strokeWidth={2.5}
+            style={{ color: DONE_MET_COLOR }} aria-hidden="true"
+          />
+        ) : (
+          <span className={`text-white/85 ${size.count} font-medium leading-none tabular-nums`}>
+            {pct}
+          </span>
+        )}
       </span>
       <span className={`text-white/35 ${size.label} uppercase tracking-[0.14em] leading-none`}>
         {t('dial.done', 'Done')}

--- a/src/components/DialComplications.test.jsx
+++ b/src/components/DialComplications.test.jsx
@@ -66,7 +66,14 @@ describe('DialComplications — the done subdial', () => {
       items: [doneItem({ doneMinutes: 180, fraction: 1, remaining: [] })],
     });
     expect(met).toContain('#22c55e');
-    expect(met).toContain('>100<');
+    // "100" is the one three-digit value and it measures 50px inside a 53px
+    // ring — jammed against the stroke. At target the ring is already full
+    // and green, so a check says it without the cramping, and the figure
+    // stays in the accessible name for anyone reading it out.
+    expect(met).not.toContain('>100<');
+    expect(met).toContain('aria-label="Done: 100%, 180 of 180 minutes"');
+    // Every other value still prints as a number.
+    expect(render(i18n, { items: [doneItem()] })).toContain('>67<');
   });
 
   it('rings it at the habit rings\' own proportions', async () => {


### PR DESCRIPTION
Follow-up to #1601.

`100` is the one three-digit value the Done subdial can show, and it **measures 50px inside a ring whose inner diameter is 53.2px** — 1.6px of clearance a side. Not an overflow, which is why no test caught it and why it only shows up when you actually complete a day. A two-digit figure sits at 33px with room to spare.

At target the ring is already full and green, so a check carries it without the cramping. `HabitRing` already says "goal met" with a green check, so the face keeps one vocabulary rather than inventing a second for the same idea.

Every other value still prints as a number, and the percentage stays in the accessible name either way — `aria-label="Done: 100%, 495 of 495 minutes"` — so nothing is lost for anyone reading it out.

Measured at both ends of the size range; the check scales with the tier (32px inner ring on the small one, 53px on the large). The test that pinned `>100<` now pins its absence plus the accessible name, and asserts the number still renders below target.

Full suite 251 files / 3430 tests, ESLint clean.

**Housekeeping:** I pushed this commit to `day-dial-completion-subdial` before noticing #1601 had already merged and that branch had been deleted, which recreated it with already-merged history. This PR is the same commit on a clean branch off `main`. The stale `day-dial-completion-subdial` branch has no PR attached and can be deleted — I don't have branch-delete access from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lj8Pw3MBmbEvYPSWLSHnPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj8Pw3MBmbEvYPSWLSHnPS)_