### PR TITLE
Month view: day-cell layout engine (headless, step 1 of 5)

### DIFF
--- a/src/constants/monthView.js
+++ b/src/constants/monthView.js
@@ -1,0 +1,50 @@
+// Month view day-cell geometry — plain data, deliberately free of component
+// code. The layout engine (utils/monthCellLayout.js) reads these, and the
+// native Android home-screen widget will draw the same cells from the same
+// numbers, so a change here is a change on every surface at once.
+//
+// A day cell is a miniature vertical timeline: vertical position encodes
+// time of day within a FIXED hour window, identical for every cell in the
+// grid. The window is never fitted to one day's contents — if it were, two
+// cells side by side would read the same pixel as different hours and the
+// grid would stop being comparable across days.
+
+export const MONTH_CELL_LAYOUT = Object.freeze({
+  /** The hours a cell maps to its full height. Items outside clamp to the edges. */
+  window: Object.freeze({ startHour: 7, endHour: 21 }),
+
+  /**
+   * A band never draws thinner than this, so a 15-minute item stays a visible
+   * mark. At a typical phone cell (~90px for a 14-hour window, ~6px per hour)
+   * a quarter hour is 1.6px; 4px reads as a line without stealing the room
+   * an hour-long band needs to read as a band.
+   */
+  minBandHeight: 4,
+
+  /**
+   * Lanes stop splitting the cell at three. A phone month grid gives each of
+   * the seven columns roughly 48px of usable width; three lanes with 1px gaps
+   * are still ~15px each and read as distinct bands, whereas four drop to
+   * ~11px and start reading as a stripe pattern. Three also matches the day
+   * grid's own drop rule (useTaskDerived's wouldExceedMaxColumns), so the
+   * month never shows more overlap than the day view lets a user create.
+   * Anything past the cap is reported as overflow instead of drawn thinner.
+   */
+  maxLanes: 3,
+
+  /** Horizontal gap between side-by-side lanes, in px. */
+  laneGap: 1,
+
+  /**
+   * Vertical gap kept between consecutive bands that share horizontal space,
+   * in px. Back-to-back items (and items pushed together by the minimum
+   * height) stay two marks instead of merging into one longer band.
+   */
+  bandGap: 1,
+});
+
+export const MONTH_CELL_HOUR_WINDOW = MONTH_CELL_LAYOUT.window;
+export const MONTH_CELL_MIN_BAND_HEIGHT = MONTH_CELL_LAYOUT.minBandHeight;
+export const MONTH_CELL_MAX_LANES = MONTH_CELL_LAYOUT.maxLanes;
+export const MONTH_CELL_LANE_GAP = MONTH_CELL_LAYOUT.laneGap;
+export const MONTH_CELL_BAND_GAP = MONTH_CELL_LAYOUT.bandGap;

--- a/src/hooks/useTaskDerived.js
+++ b/src/hooks/useTaskDerived.js
@@ -1,10 +1,25 @@
 import { getOccurrencesInRange } from '../utils/recurrenceEngine.js';
+import { assignLanes } from '../utils/intervalLanes.js';
 import useTaskMeasurement from './useTaskMeasurement.js';
 
 const timeToMinutes = (time) => {
   const [hours, minutes] = time.split(':').map(Number);
   return hours * 60 + minutes;
 };
+
+// Pack a day's tasks into side-by-side columns. Sorting decides who gets the
+// lower column on a start-time tie; the packing itself (overlap clusters,
+// first-fit columns, per-cluster column counts) is the shared interval packer
+// that the Day Dial and the month view use too, so every surface agrees on
+// which tasks share a column.
+const packTaskColumns = (tasks, compare) => assignLanes(
+  tasks
+    .map((task) => {
+      const startMin = timeToMinutes(task.startTime);
+      return { task, startMin, endMin: startMin + task.duration };
+    })
+    .sort(compare),
+);
 
 export default function useTaskDerived({ tasks, recurringTasks, visibleDays, mobileActiveTab }) {
   const { taskWidths, setTaskRef } = useTaskMeasurement({ tasks, visibleDays, mobileActiveTab });
@@ -27,66 +42,17 @@ export default function useTaskDerived({ tasks, recurringTasks, visibleDays, mob
 
     // Filter out imported events from conflict calculations
     const nonImportedTasks = allTasks.filter(t => !t.imported || t.isTaskCalendar);
-    const conflicting = getConflictingTasks(task, nonImportedTasks);
-    if (conflicting.length === 0) return { left: 2, right: 2, width: null, totalColumns: 1 };
-
-    // Build the full conflict cluster using transitive closure
-    const buildConflictCluster = (startTask) => {
-      const cluster = new Set([startTask.id]);
-      const queue = [startTask];
-
-      while (queue.length > 0) {
-        const current = queue.shift();
-        const currentConflicts = getConflictingTasks(current, nonImportedTasks);
-        for (const t of currentConflicts) {
-          if (!cluster.has(t.id)) {
-            cluster.add(t.id);
-            queue.push(t);
-          }
-        }
-      }
-
-      return nonImportedTasks.filter(t => cluster.has(t.id));
-    };
-
-    const cluster = buildConflictCluster(task);
 
     // Sort by start time, then by id for stable column assignment during resize
-    const sorted = [...cluster].sort((a, b) => {
-      const aStart = timeToMinutes(a.startTime);
-      const bStart = timeToMinutes(b.startTime);
-      if (aStart !== bStart) return aStart - bStart;
-      return String(a.id).localeCompare(String(b.id));
+    const packed = packTaskColumns(nonImportedTasks, (a, b) => {
+      if (a.startMin !== b.startMin) return a.startMin - b.startMin;
+      return String(a.task.id).localeCompare(String(b.task.id));
     });
+    const placed = packed.find(p => p.task.id === task.id);
+    if (!placed || placed.laneCount <= 1) return { left: 2, right: 2, width: null, totalColumns: 1 };
 
-    // Greedy column assignment: place each task in the first column where it fits
-    const columns = []; // Each column tracks the end time of the last task in it
-    const taskColumns = new Map();
-
-    for (const t of sorted) {
-      const tStart = timeToMinutes(t.startTime);
-      const tEnd = tStart + t.duration;
-
-      // Find first column where this task fits (doesn't overlap)
-      let placed = false;
-      for (let col = 0; col < columns.length; col++) {
-        if (columns[col] <= tStart) {
-          columns[col] = tEnd;
-          taskColumns.set(t.id, col);
-          placed = true;
-          break;
-        }
-      }
-
-      // If no column fits, create a new one
-      if (!placed) {
-        taskColumns.set(t.id, columns.length);
-        columns.push(tEnd);
-      }
-    }
-
-    const totalColumns = columns.length;
-    const column = taskColumns.get(task.id);
+    const totalColumns = placed.laneCount;
+    const column = placed.lane;
 
     const widthPercent = 100 / totalColumns;
     const leftPercent = widthPercent * column;
@@ -129,55 +95,14 @@ export default function useTaskDerived({ tasks, recurringTasks, visibleDays, mob
     const hypotheticalTask = { ...droppedTask, startTime, date: dropDateStr };
     const allTasks = [...existingTasks, hypotheticalTask];
 
-    // Check if this task would conflict with anything
-    const conflicting = getConflictingTasks(hypotheticalTask, allTasks);
-    if (conflicting.length === 0) return false;
-
-    // Build conflict cluster and calculate columns (same logic as calculateConflictPosition)
-    const buildCluster = (startTask) => {
-      const cluster = new Set([startTask.id]);
-      const queue = [startTask];
-      while (queue.length > 0) {
-        const current = queue.shift();
-        const currentConflicts = getConflictingTasks(current, allTasks);
-        for (const t of currentConflicts) {
-          if (!cluster.has(t.id)) {
-            cluster.add(t.id);
-            queue.push(t);
-          }
-        }
-      }
-      return allTasks.filter(t => cluster.has(t.id));
-    };
-
-    const cluster = buildCluster(hypotheticalTask);
-    const sorted = [...cluster].sort((a, b) => {
-      const aStart = timeToMinutes(a.startTime);
-      const bStart = timeToMinutes(b.startTime);
-      if (aStart !== bStart) return aStart - bStart;
-      if (a.duration !== b.duration) return b.duration - a.duration;
-      return String(a.id).localeCompare(String(b.id));
+    // Longer tasks claim the lower column on a start-time tie.
+    const packed = packTaskColumns(allTasks, (a, b) => {
+      if (a.startMin !== b.startMin) return a.startMin - b.startMin;
+      if (a.task.duration !== b.task.duration) return b.task.duration - a.task.duration;
+      return String(a.task.id).localeCompare(String(b.task.id));
     });
-
-    // Greedy column assignment
-    const columns = [];
-    for (const t of sorted) {
-      const tStart = timeToMinutes(t.startTime);
-      const tEnd = tStart + t.duration;
-      let placed = false;
-      for (let col = 0; col < columns.length; col++) {
-        if (columns[col] <= tStart) {
-          columns[col] = tEnd;
-          placed = true;
-          break;
-        }
-      }
-      if (!placed) {
-        columns.push(tEnd);
-      }
-    }
-
-    return columns.length > maxColumns;
+    const placed = packed.find(p => p.task === hypotheticalTask);
+    return !!placed && placed.laneCount > maxColumns;
   };
 
   return {

--- a/src/utils/dayDial.js
+++ b/src/utils/dayDial.js
@@ -2,6 +2,7 @@ import { computeDaySummary } from './daySummary.js';
 import { deriveBlockEnergy } from './energyAxis.js';
 import { taskColorToHex } from './colorUtils.js';
 import { getPeakSunElevation, getSunElevation, POLAR_DAY } from './solar.js';
+import { assignLanes } from './intervalLanes.js';
 
 // Model + geometry for the Day Dial — the ambient 24-hour instrument view.
 // Pure functions only: DayDial.jsx stays presentational and every angle,
@@ -138,34 +139,9 @@ export function padDialSegment(startMin, endMin, gapMin = 3, padStart = true, pa
  * @returns New block objects carrying {lane, laneCount}, in the same order.
  */
 export function assignDialLanes(blocks) {
-  const out = [];
-  let cluster = [];
-  let clusterEnd = -Infinity;
-  let laneEnds = [];
-
-  // One cluster's lane count applies to every block in it, so a wedge keeps
-  // the same depth for as long as the pile-up lasts instead of stepping
-  // radially mid-cluster.
-  const flush = () => {
-    for (const b of cluster) out.push({ ...b, laneCount: laneEnds.length });
-    cluster = [];
-    laneEnds = [];
-  };
-
-  for (const b of blocks || []) {
-    if (b.startMin >= clusterEnd) {
-      flush();
-      clusterEnd = b.endMin;
-    } else {
-      clusterEnd = Math.max(clusterEnd, b.endMin);
-    }
-    let lane = laneEnds.findIndex((end) => end <= b.startMin);
-    if (lane === -1) lane = laneEnds.length;
-    laneEnds[lane] = b.endMin;
-    cluster.push({ ...b, lane });
-  }
-  flush();
-  return out;
+  // The packing itself is shared with the time grids and the month view
+  // (intervalLanes.js); the dial only names its own semantics for it.
+  return assignLanes(blocks);
 }
 
 // Radial breathing room between lanes, in viewBox units. Yields on crowded

--- a/src/utils/intervalLanes.js
+++ b/src/utils/intervalLanes.js
@@ -6,8 +6,11 @@
 // would pack differently from view to view.
 //
 // Intervals are half-open [startMin, endMin): back-to-back blocks touch but
-// do not overlap, so they share a lane. Callers exclude empty intervals
-// (endMin <= startMin) — a moment is a marker, not a block.
+// do not overlap, so they share a lane. An interval with no positive span
+// (endMin <= startMin, or either bound missing or NaN) is a moment, not a
+// block: it takes lane 0 at full width and never joins or extends a cluster.
+// That is also what a NaN end must not be allowed to do — a cluster end of
+// NaN never closes and would swallow every later block in the day.
 //
 // Algorithm: a single sweep over start-sorted input. Blocks whose spans chain
 // together form one overlap cluster (the transitive closure a BFS would find,
@@ -30,12 +33,18 @@ export function assignLanes(intervals) {
   let laneEnds = [];
 
   const flush = () => {
-    for (const b of cluster) out.push({ ...b, laneCount: laneEnds.length });
+    for (const { solo, ...b } of cluster) out.push(solo ? b : { ...b, laneCount: laneEnds.length });
     cluster = [];
     laneEnds = [];
   };
 
   for (const b of intervals || []) {
+    if (!(b.endMin > b.startMin)) {
+      // No span (also catches NaN and missing bounds): outside packing
+      // entirely, but emitted in place so the output order still matches.
+      cluster.push({ ...b, lane: 0, laneCount: 1, solo: true });
+      continue;
+    }
     if (b.startMin >= clusterEnd) {
       flush();
       clusterEnd = b.endMin;

--- a/src/utils/intervalLanes.js
+++ b/src/utils/intervalLanes.js
@@ -1,0 +1,59 @@
+// Interval lane packing — the one place dayGLANCE decides how overlapping
+// blocks stack side by side. Pure. Used by the Day Dial ring, the day/mobile
+// time grids (via useTaskDerived), and the month view's day cells; each
+// surface maps lanes to its own geometry (radial depth, CSS columns, pixel
+// lanes) but they must agree on which blocks share a lane, or the same day
+// would pack differently from view to view.
+//
+// Intervals are half-open [startMin, endMin): back-to-back blocks touch but
+// do not overlap, so they share a lane. Callers exclude empty intervals
+// (endMin <= startMin) — a moment is a marker, not a block.
+//
+// Algorithm: a single sweep over start-sorted input. Blocks whose spans chain
+// together form one overlap cluster (the transitive closure a BFS would find,
+// but O(n) because the input is sorted), and inside a cluster each block takes
+// the first lane that has freed up. The lane count is scoped to the cluster —
+// a three-deep pile-up at noon must not thin a lone block at 4pm — and it is
+// stamped onto every member so a block knows how wide its neighbourhood is.
+
+/**
+ * @param {Array<{startMin: number, endMin: number}>} intervals
+ *   Sorted by startMin ascending (ties in whatever order the caller wants
+ *   lanes handed out: the earlier entry gets the lower lane). Order is
+ *   preserved in the output.
+ * @returns {Array<object>} New objects: each input spread with {lane, laneCount}.
+ */
+export function assignLanes(intervals) {
+  const out = [];
+  let cluster = [];
+  let clusterEnd = -Infinity;
+  let laneEnds = [];
+
+  const flush = () => {
+    for (const b of cluster) out.push({ ...b, laneCount: laneEnds.length });
+    cluster = [];
+    laneEnds = [];
+  };
+
+  for (const b of intervals || []) {
+    if (b.startMin >= clusterEnd) {
+      flush();
+      clusterEnd = b.endMin;
+    } else {
+      clusterEnd = Math.max(clusterEnd, b.endMin);
+    }
+    let lane = laneEnds.findIndex((end) => end <= b.startMin);
+    if (lane === -1) lane = laneEnds.length;
+    laneEnds[lane] = b.endMin;
+    cluster.push({ ...b, lane });
+  }
+  flush();
+  return out;
+}
+
+/** The most lanes any cluster in a packed list needed (0 for an empty list). */
+export function maxLaneCount(packed) {
+  let max = 0;
+  for (const b of packed || []) if (b.laneCount > max) max = b.laneCount;
+  return max;
+}

--- a/src/utils/intervalLanes.test.js
+++ b/src/utils/intervalLanes.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { assignLanes, maxLaneCount } from './intervalLanes.js';
+
+const iv = (startMin, endMin, id = `${startMin}`) => ({ id, startMin, endMin });
+
+describe('assignLanes', () => {
+  it('keeps non-overlapping and back-to-back intervals on one lane', () => {
+    const laid = assignLanes([iv(540, 600), iv(600, 660), iv(700, 760)]);
+    expect(laid.map((b) => [b.lane, b.laneCount])).toEqual([[0, 1], [0, 1], [0, 1]]);
+  });
+
+  it('opens a second lane for a genuine overlap and reuses it once freed', () => {
+    const laid = assignLanes([iv(600, 660, 'a'), iv(630, 720, 'b'), iv(675, 720, 'c')]);
+    expect(laid.map((b) => b.lane)).toEqual([0, 1, 0]);
+    expect(laid.map((b) => b.laneCount)).toEqual([2, 2, 2]);
+  });
+
+  it('chains transitively: a bridging block joins its neighbours into one cluster', () => {
+    // a and c never overlap each other, but both overlap b.
+    const laid = assignLanes([iv(540, 600, 'a'), iv(570, 660, 'b'), iv(630, 700, 'c')]);
+    expect(laid.map((b) => [b.id, b.lane, b.laneCount])).toEqual([
+      ['a', 0, 2], ['b', 1, 2], ['c', 0, 2],
+    ]);
+  });
+
+  it('scopes the lane count to each cluster', () => {
+    const laid = assignLanes([
+      iv(480, 540, 'morning'),
+      iv(600, 700, 'x'), iv(620, 720, 'y'), iv(640, 700, 'z'),
+      iv(800, 860, 'evening'),
+    ]);
+    expect(laid.map((b) => [b.id, b.lane, b.laneCount])).toEqual([
+      ['morning', 0, 1],
+      ['x', 0, 3], ['y', 1, 3], ['z', 2, 3],
+      ['evening', 0, 1],
+    ]);
+    expect(maxLaneCount(laid)).toBe(3);
+  });
+
+  it('preserves input order and does not mutate the input', () => {
+    const input = [iv(540, 600, 'a'), iv(540, 570, 'b')];
+    const laid = assignLanes(input);
+    expect(laid.map((b) => b.id)).toEqual(['a', 'b']);
+    expect(input[0]).toEqual({ id: 'a', startMin: 540, endMin: 600 });
+  });
+
+  it('handles empty and missing input', () => {
+    expect(assignLanes([])).toEqual([]);
+    expect(assignLanes(null)).toEqual([]);
+    expect(maxLaneCount([])).toBe(0);
+  });
+});

--- a/src/utils/intervalLanes.test.js
+++ b/src/utils/intervalLanes.test.js
@@ -44,6 +44,47 @@ describe('assignLanes', () => {
     expect(input[0]).toEqual({ id: 'a', startMin: 540, endMin: 600 });
   });
 
+  describe('intervals with no positive span stay out of packing', () => {
+    // Several later blocks that genuinely overlap: they must still cluster
+    // and pack exactly as they would without the spanless entry present.
+    const later = [iv(600, 700, 'x'), iv(620, 720, 'y'), iv(640, 700, 'z'), iv(800, 860, 'evening')];
+    const expectLaterNormal = (laid) => {
+      expect(laid.filter((b) => later.some((l) => l.id === b.id)).map((b) => [b.id, b.lane, b.laneCount]))
+        .toEqual([['x', 0, 3], ['y', 1, 3], ['z', 2, 3], ['evening', 0, 1]]);
+    };
+
+    it.each([
+      ['duration 0', { id: 'm', startMin: 600, endMin: 600 }],
+      ['duration missing', { id: 'm', startMin: 600 }],
+      ['duration NaN', { id: 'm', startMin: 600, endMin: NaN }],
+      ['negative span', { id: 'm', startMin: 600, endMin: 590 }],
+      ['start missing', { id: 'm', endMin: 630 }],
+    ])('%s: lane 0, full width, in place, later blocks unaffected', (_label, moment) => {
+      const laid = assignLanes([iv(540, 580, 'before'), moment, ...later]);
+      expect(laid.map((b) => b.id)).toEqual(['before', 'm', 'x', 'y', 'z', 'evening']);
+      expect(laid[1]).toEqual({ ...moment, lane: 0, laneCount: 1 });
+      expect(laid[0]).toMatchObject({ lane: 0, laneCount: 1 });
+      expectLaterNormal(laid);
+      expect(laid.some((b) => 'solo' in b)).toBe(false);
+    });
+
+    it('a moment at the exact start of a block does not open a second lane', () => {
+      const laid = assignLanes([iv(540, 600, 'a'), { id: 'm', startMin: 540, endMin: 540 }]);
+      expect(laid.map((b) => [b.id, b.lane, b.laneCount])).toEqual([['a', 0, 1], ['m', 0, 1]]);
+    });
+
+    it('a moment inside a cluster neither joins nor splits it', () => {
+      const laid = assignLanes([iv(540, 600, 'a'), { id: 'm', startMin: 550, endMin: 550 }, iv(570, 630, 'b')]);
+      expect(laid.map((b) => [b.id, b.lane, b.laneCount])).toEqual([['a', 0, 2], ['m', 0, 1], ['b', 1, 2]]);
+    });
+
+    it('a NaN end never becomes the cluster end', () => {
+      const laid = assignLanes([{ id: 'm', startMin: 540, endMin: NaN }, iv(560, 600, 'a'), iv(700, 760, 'b')]);
+      expect(laid.map((b) => [b.id, b.lane, b.laneCount])).toEqual([['m', 0, 1], ['a', 0, 1], ['b', 0, 1]]);
+      expect(maxLaneCount(laid)).toBe(1);
+    });
+  });
+
   it('handles empty and missing input', () => {
     expect(assignLanes([])).toEqual([]);
     expect(assignLanes(null)).toEqual([]);

--- a/src/utils/monthCellLayout.fixture.js
+++ b/src/utils/monthCellLayout.fixture.js
@@ -1,0 +1,73 @@
+// A realistically busy weekday for the month-cell layout, built from raw app
+// data and run through agenda-core's own expansion (buildAgenda for tasks,
+// recurring instances and calendar events; routinesForDate for routines) so
+// the fixture carries exactly the item shapes the month view will receive.
+//
+// The day, in order:
+//   06:30–07:00  Morning run (routine)          — starts before the window
+//   07:00–07:30  Breakfast (routine)
+//   08:30–09:00  Standup (calendar event)
+//   09:00–10:30  Deep work: spec (task)
+//   09:30–10:00  1:1 with Sam (calendar event)  — overlaps deep work
+//   10:00–10:15  Quick call (task)              — 15 min, overlaps deep work
+//   11:00        Dentist reminder (task, no duration) — a point
+//   12:00–13:00  Lunch (routine)
+//   13:00–14:00  Team meeting (calendar event)
+//   13:30–14:30  Review PR (task)               — three-way overlap
+//   13:45–14:15  Interview (calendar event)     —   with these two
+//   15:00–15:15  Stretch (routine)              — 15 min
+//   16:00–17:30  Workshop (weekly recurring task)
+//   18:30–19:30  Gym (routine)
+//   20:30–22:00  Dinner out (calendar event)    — runs past the window
+//   22:30–23:00  Wind down (routine)            — entirely after the window
+//   all day      Mom's birthday (calendar event), Submit expense report (task)
+
+import { buildAgenda, routinesForDate } from '@glance-apps/agenda-core';
+
+export const FIXTURE_DATE = '2026-09-16';
+
+export function busyDayData() {
+  return {
+    tasks: [
+      { id: 't-deep', title: 'Deep work: spec', date: FIXTURE_DATE, startTime: '09:00', duration: 90, color: 'bg-blue-500', completed: false },
+      { id: 't-call', title: 'Quick call', date: FIXTURE_DATE, startTime: '10:00', duration: 15, color: 'bg-green-500', completed: true },
+      { id: 't-dentist', title: 'Dentist reminder', date: FIXTURE_DATE, startTime: '11:00', duration: 0, color: 'bg-red-500', completed: false },
+      { id: 't-review', title: 'Review PR', date: FIXTURE_DATE, startTime: '13:30', duration: 60, color: 'bg-purple-500', completed: false },
+      { id: 't-expense', title: 'Submit expense report', date: FIXTURE_DATE, isAllDay: true, startTime: '00:00', duration: 0, completed: false },
+      { id: 't-other-day', title: 'Not today', date: '2026-09-17', startTime: '09:00', duration: 30, completed: false },
+      { id: 'ev-standup', title: 'Standup', date: FIXTURE_DATE, startTime: '08:30', duration: 30, imported: true, completed: false },
+      { id: 'ev-1on1', title: '1:1 with Sam', date: FIXTURE_DATE, startTime: '09:30', duration: 30, imported: true, completed: false },
+    ],
+    recurringTasks: [
+      {
+        id: 'r-workshop', title: 'Workshop', startTime: '16:00', duration: 90, color: 'bg-amber-500',
+        recurrence: { type: 'weekly', interval: 1, startDate: '2026-09-02', daysOfWeek: [3] },
+        completedDates: [], exceptions: {},
+      },
+    ],
+    calendarEvents: [
+      { id: 'cal-team', title: 'Team meeting', date: FIXTURE_DATE, startTime: '13:00', duration: 60, calendarName: 'Work' },
+      { id: 'cal-interview', title: 'Interview', date: FIXTURE_DATE, startTime: '13:45', duration: 30, calendarName: 'Work' },
+      { id: 'cal-dinner', title: 'Dinner out', date: FIXTURE_DATE, startTime: '20:30', duration: 90, calendarName: 'Personal' },
+      { id: 'cal-bday', title: "Mom's birthday", date: FIXTURE_DATE, isAllDay: true, calendarName: 'Personal' },
+    ],
+    todayRoutines: [
+      { id: 'ro-run', name: 'Morning run', startTime: '06:30', duration: 30 },
+      { id: 'ro-breakfast', name: 'Breakfast', startTime: '07:00', duration: 30 },
+      { id: 'ro-lunch', name: 'Lunch', startTime: '12:00', duration: 60 },
+      { id: 'ro-stretch', name: 'Stretch', startTime: '15:00', duration: 15 },
+      { id: 'ro-gym', name: 'Gym', startTime: '18:30', duration: 60 },
+      { id: 'ro-wind', name: 'Wind down', startTime: '22:30', duration: 30 },
+    ],
+    routinesDate: FIXTURE_DATE,
+    routineCompletions: { 'ro-run': FIXTURE_DATE },
+  };
+}
+
+/** The fixture as { agenda: AgendaItem[], routines: RoutineItem[] } for FIXTURE_DATE. */
+export function busyDayItems() {
+  const data = busyDayData();
+  const agenda = buildAgenda(data, { from: FIXTURE_DATE, to: FIXTURE_DATE })[FIXTURE_DATE] || [];
+  const routines = routinesForDate(data, FIXTURE_DATE);
+  return { agenda, routines };
+}

--- a/src/utils/monthCellLayout.js
+++ b/src/utils/monthCellLayout.js
@@ -1,0 +1,231 @@
+// Month view day-cell layout engine. Pure: no React, no DOM, no rendering.
+//
+// A day cell is a miniature vertical timeline. Vertical position encodes time
+// of day within the FIXED hour window from constants/monthView.js, so a band's
+// position says when something is and the empty space says when the day is
+// free. Events, tasks and routines all become bands, distinguished only by
+// `kind` (the renderer picks the colour, and draws routines faintly). Items
+// that overlap in time split the cell into lanes; a day with no overlaps uses
+// one lane spanning the usable width. Items with a moment but no duration
+// become point markers; items with no time at all are listed as all-day so
+// the renderer can pin them under the date number. There is no text in a
+// cell, so nothing here measures or truncates a title.
+//
+// Input items are the agenda shapes the app already has: AgendaItem from
+// buildAgenda (tasks, recurring instances, imported and projected calendar
+// events) and RoutineItem from routinesForDate. Routines have no `date` and
+// nothing that marks them as routines, so the caller tags them (tagKind).
+//
+// Everything returned is in pixels relative to the cell's own origin.
+
+import { isCalendarEvent } from '@glance-apps/agenda-core';
+import { MONTH_CELL_LAYOUT } from '../constants/monthView.js';
+import { assignLanes, maxLaneCount } from './intervalLanes.js';
+
+export const DAY_CELL_KINDS = Object.freeze(['event', 'task', 'routine']);
+
+/** Stamp a kind onto items that cannot be told apart by shape (routines). */
+export const tagKind = (items, kind) => (items || []).map((item) => ({ ...item, kind }));
+
+/**
+ * The band kind for an item: an explicit `kind` wins; otherwise an imported
+ * calendar event (agenda-core's own rule) is an event and everything else a
+ * task.
+ */
+export function dayCellItemKind(item) {
+  if (DAY_CELL_KINDS.includes(item?.kind)) return item.kind;
+  return isCalendarEvent(item) ? 'event' : 'task';
+}
+
+const parseMinutes = (hhmm) => {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(String(hhmm ?? ''));
+  return m ? Number(m[1]) * 60 + Number(m[2]) : null;
+};
+
+const xOverlaps = (a, b) => a.x < b.x + b.width && b.x < a.x + a.width;
+
+/**
+ * Keep bands that share horizontal space from touching or overlapping in
+ * pixels. Overlap in TIME is already resolved by lanes; this handles the
+ * pixel collisions the minimum band height introduces (and the zero gap
+ * between back-to-back items). A pushed band keeps its end edge where it was
+ * when it can, so time fidelity is lost only where the minimum height
+ * demands it; a downward pass resolves from the top, an upward pass keeps
+ * everything inside the cell, and if the cell simply cannot fit them all the
+ * caller is told (`crowded`) instead of the bands silently piling up.
+ */
+function separateBands(bands, cellHeight, minBandHeight, bandGap) {
+  const byY = [...bands].sort((a, b) => a.y - b.y || a.x - b.x);
+
+  for (let i = 0; i < byY.length; i++) {
+    const band = byY[i];
+    let floor = -Infinity;
+    for (let j = 0; j < i; j++) {
+      const prev = byY[j];
+      if (xOverlaps(prev, band)) floor = Math.max(floor, prev.y + prev.height + bandGap);
+    }
+    if (band.y < floor) {
+      const bottom = band.y + band.height;
+      band.y = floor;
+      band.height = Math.max(minBandHeight, bottom - floor);
+    }
+  }
+
+  for (let i = byY.length - 1; i >= 0; i--) {
+    const band = byY[i];
+    let ceiling = cellHeight;
+    for (let j = byY.length - 1; j > i; j--) {
+      const next = byY[j];
+      if (xOverlaps(next, band)) ceiling = Math.min(ceiling, next.y - bandGap);
+    }
+    if (band.y + band.height > ceiling) {
+      band.height = Math.max(minBandHeight, ceiling - band.y);
+      band.y = ceiling - band.height;
+    }
+  }
+
+  let crowded = false;
+  for (let i = 0; i < byY.length; i++) {
+    const band = byY[i];
+    if (band.y < 0) { band.y = 0; crowded = true; }
+    if (band.y + band.height > cellHeight) { band.y = Math.max(0, cellHeight - band.height); crowded = true; }
+    for (let j = 0; j < i; j++) {
+      const prev = byY[j];
+      if (xOverlaps(prev, band) && band.y < prev.y + prev.height + bandGap) crowded = true;
+    }
+  }
+  return crowded;
+}
+
+/**
+ * Lay out one day cell.
+ *
+ * @param {Array<object>} items   AgendaItem / RoutineItem shapes for this day
+ *   (routines tagged with kind: 'routine' via tagKind). An item carrying a
+ *   `date` that is not `date` is ignored, so a whole agenda may be passed.
+ * @param {string} date           YYYY-MM-DD of the cell.
+ * @param {number} cellWidth      Cell width in px.
+ * @param {number} cellHeight     Cell height in px.
+ * @param {object} [options]
+ * @param {number} [options.gutterWidth=0]  Right-hand gutter reserved for
+ *   point markers (desktop). Subtracted from the usable band width.
+ * @param {{startHour:number,endHour:number}} [options.window]  The hour
+ *   window. Defaults to the shared constant and MUST be the same for every
+ *   cell in a grid; it exists as an option only for a user-level setting or
+ *   a test, never to fit one day's contents.
+ * @param {number} [options.minBandHeight]  See constants/monthView.js.
+ * @param {number} [options.maxLanes]
+ * @param {number} [options.laneGap]
+ * @param {number} [options.bandGap]
+ *
+ * @returns {{
+ *   date: string, cellWidth: number, cellHeight: number,
+ *   gutterWidth: number, usableWidth: number,
+ *   window: { startMinutes: number, endMinutes: number },
+ *   laneCount: number,
+ *   bands: Array<{ id: string, kind: string, completed: boolean,
+ *                  lane: number, laneCount: number,
+ *                  x: number, y: number, width: number, height: number,
+ *                  clampedStart: boolean, clampedEnd: boolean }>,
+ *   points: Array<{ id: string, kind: string, completed: boolean,
+ *                   x: number, y: number, clamped: 'before'|'after'|null }>,
+ *   allDay: Array<{ id: string, kind: string, completed: boolean }>,
+ *   overflow: { lanesNeeded: number, hidden: string[], crowded: boolean },
+ *   hasOverflow: boolean,
+ * }}
+ */
+export function layoutDayCell(items, date, cellWidth, cellHeight, options = {}) {
+  const {
+    gutterWidth = 0,
+    window: hourWindow = MONTH_CELL_LAYOUT.window,
+    minBandHeight = MONTH_CELL_LAYOUT.minBandHeight,
+    maxLanes = MONTH_CELL_LAYOUT.maxLanes,
+    laneGap = MONTH_CELL_LAYOUT.laneGap,
+    bandGap = MONTH_CELL_LAYOUT.bandGap,
+  } = options;
+
+  const startMinutes = hourWindow.startHour * 60;
+  const endMinutes = hourWindow.endHour * 60;
+  const span = Math.max(1, endMinutes - startMinutes);
+  const usableWidth = Math.max(0, cellWidth - Math.max(0, gutterWidth));
+  const yFor = (min) => {
+    const t = Math.min(1, Math.max(0, (min - startMinutes) / span));
+    return t * cellHeight;
+  };
+
+  const allDay = [];
+  const points = [];
+  const timed = [];
+
+  for (const item of items || []) {
+    if (!item || item.id == null) continue;
+    if (item.date && date && item.date !== date) continue;
+    const id = String(item.id);
+    const kind = dayCellItemKind(item);
+    const completed = !!item.completed;
+    // Keyed on the flag first, never only on a missing startTime: an
+    // Obsidian date-only line arrives as isAllDay with startTime '00:00'
+    // (see computeDialModel), and drawing that at midnight invents an hour.
+    const startMin = item.isAllDay ? null : parseMinutes(item.startTime);
+    if (startMin === null) { allDay.push({ id, kind, completed }); continue; }
+    const duration = Number(item.duration) > 0 ? Number(item.duration) : 0;
+    if (duration === 0) {
+      const clamped = startMin < startMinutes ? 'before' : startMin > endMinutes ? 'after' : null;
+      const x = gutterWidth > 0 ? usableWidth + gutterWidth / 2 : usableWidth / 2;
+      points.push({ id, kind, completed, x, y: yFor(startMin), clamped });
+      continue;
+    }
+    timed.push({ id, kind, completed, startMin, endMin: startMin + duration });
+  }
+
+  // Earlier first; on a tie the longer item takes the lower lane; then id, so
+  // the same day always packs the same way.
+  timed.sort((a, b) => a.startMin - b.startMin || b.endMin - a.endMin || a.id.localeCompare(b.id));
+  const packed = assignLanes(timed);
+  const lanesNeeded = maxLaneCount(packed);
+
+  const bands = [];
+  const hidden = [];
+  for (const p of packed) {
+    if (p.lane >= maxLanes) { hidden.push(p.id); continue; }
+    const laneCount = Math.min(p.laneCount, maxLanes);
+    const laneWidth = Math.max(0, (usableWidth - laneGap * (laneCount - 1)) / laneCount);
+    const y0 = yFor(p.startMin);
+    const y1 = yFor(p.endMin);
+    let height = Math.max(minBandHeight, y1 - y0);
+    let y = y0;
+    if (y + height > cellHeight) y = Math.max(0, cellHeight - height);
+    if (height > cellHeight) height = cellHeight;
+    bands.push({
+      id: p.id,
+      kind: p.kind,
+      completed: p.completed,
+      lane: p.lane,
+      laneCount,
+      x: p.lane * (laneWidth + laneGap),
+      y,
+      width: laneWidth,
+      height,
+      clampedStart: p.startMin < startMinutes,
+      clampedEnd: p.endMin > endMinutes,
+    });
+  }
+
+  const crowded = separateBands(bands, cellHeight, minBandHeight, bandGap);
+
+  const overflow = { lanesNeeded, hidden, crowded };
+  return {
+    date,
+    cellWidth,
+    cellHeight,
+    gutterWidth: Math.max(0, gutterWidth),
+    usableWidth,
+    window: { startMinutes, endMinutes },
+    laneCount: Math.max(1, Math.min(lanesNeeded, maxLanes)),
+    bands,
+    points,
+    allDay,
+    overflow,
+    hasOverflow: hidden.length > 0 || crowded,
+  };
+}

--- a/src/utils/monthCellLayout.test.js
+++ b/src/utils/monthCellLayout.test.js
@@ -1,0 +1,378 @@
+import { describe, it, expect } from 'vitest';
+import { layoutDayCell, dayCellItemKind, tagKind } from './monthCellLayout.js';
+import { MONTH_CELL_LAYOUT } from '../constants/monthView.js';
+import { FIXTURE_DATE, busyDayItems } from './monthCellLayout.fixture.js';
+
+// 07:00–21:00 is 14 hours; a 140px cell makes an hour 10px, a minute 1/6px.
+const DATE = '2026-09-16';
+const W = 50;
+const H = 140;
+const { minBandHeight, laneGap, bandGap, maxLanes } = MONTH_CELL_LAYOUT;
+
+const task = (id, startTime, duration, extra = {}) =>
+  ({ id, title: id, date: DATE, startTime, duration, isAllDay: false, completed: false, ...extra });
+const event = (id, startTime, duration, extra = {}) => task(id, startTime, duration, { imported: true, ...extra });
+
+const byId = (list, id) => list.find((b) => b.id === id);
+
+// Two bands that share horizontal space must never touch or overlap vertically.
+const xOverlaps = (a, b) => a.x < b.x + b.width && b.x < a.x + a.width;
+function expectNoPixelCollisions(bands, gap = bandGap) {
+  for (let i = 0; i < bands.length; i++) {
+    for (let j = i + 1; j < bands.length; j++) {
+      const a = bands[i], b = bands[j];
+      if (!xOverlaps(a, b)) continue;
+      const separated = a.y + a.height + gap <= b.y || b.y + b.height + gap <= a.y;
+      expect(separated, `${a.id} and ${b.id} collide`).toBe(true);
+    }
+  }
+}
+
+describe('constants', () => {
+  it('exports the hour window and geometry as plain frozen data', () => {
+    expect(MONTH_CELL_LAYOUT.window).toEqual({ startHour: 7, endHour: 21 });
+    expect(Object.isFrozen(MONTH_CELL_LAYOUT)).toBe(true);
+    expect(minBandHeight).toBeGreaterThan(0);
+    expect(maxLanes).toBe(3);
+    expect(laneGap).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('layoutDayCell — empty day', () => {
+  it('returns empty collections, one lane, and no overflow', () => {
+    const out = layoutDayCell([], DATE, W, H);
+    expect(out.bands).toEqual([]);
+    expect(out.points).toEqual([]);
+    expect(out.allDay).toEqual([]);
+    expect(out.laneCount).toBe(1);
+    expect(out.hasOverflow).toBe(false);
+    expect(out.overflow).toEqual({ lanesNeeded: 0, hidden: [], crowded: false });
+    expect(out.window).toEqual({ startMinutes: 420, endMinutes: 1260 });
+    expect(out.usableWidth).toBe(W);
+    expect(layoutDayCell(null, DATE, W, H).bands).toEqual([]);
+  });
+});
+
+describe('layoutDayCell — single item', () => {
+  it('spans the usable width on one lane at the hour-window position', () => {
+    const out = layoutDayCell([task('a', '09:00', 60)], DATE, W, H);
+    expect(out.laneCount).toBe(1);
+    expect(out.bands).toHaveLength(1);
+    expect(out.bands[0]).toMatchObject({
+      id: 'a', kind: 'task', lane: 0, laneCount: 1,
+      x: 0, y: 20, width: W, height: 10,
+      clampedStart: false, clampedEnd: false, completed: false,
+    });
+  });
+
+  it('carries completion through for the renderer', () => {
+    const out = layoutDayCell([task('a', '09:00', 60, { completed: true })], DATE, W, H);
+    expect(out.bands[0].completed).toBe(true);
+  });
+});
+
+describe('layoutDayCell — overlap lanes', () => {
+  it('splits two overlapping items into two lanes of half the usable width', () => {
+    const out = layoutDayCell([task('a', '09:00', 60), task('b', '09:30', 60)], DATE, W, H);
+    expect(out.laneCount).toBe(2);
+    const laneWidth = (W - laneGap) / 2;
+    expect(byId(out.bands, 'a')).toMatchObject({ lane: 0, laneCount: 2, x: 0, width: laneWidth, y: 20, height: 10 });
+    expect(byId(out.bands, 'b')).toMatchObject({ lane: 1, laneCount: 2, x: laneWidth + laneGap, width: laneWidth, y: 25, height: 10 });
+    expect(out.hasOverflow).toBe(false);
+  });
+
+  it('gives a three-way overlap three lanes', () => {
+    const out = layoutDayCell([
+      event('team', '13:00', 60), task('review', '13:30', 60), event('interview', '13:45', 30),
+    ], DATE, W, H);
+    expect(out.laneCount).toBe(3);
+    const laneWidth = (W - 2 * laneGap) / 3;
+    expect(out.bands.map((b) => [b.id, b.lane, b.laneCount])).toEqual([
+      ['team', 0, 3], ['review', 1, 3], ['interview', 2, 3],
+    ]);
+    for (const b of out.bands) {
+      expect(b.width).toBeCloseTo(laneWidth);
+      expect(b.x).toBeCloseTo(b.lane * (laneWidth + laneGap));
+    }
+  });
+
+  it('keeps a lone item full width even when another part of the day overlaps', () => {
+    const out = layoutDayCell([
+      task('solo', '08:00', 60), task('a', '13:00', 60), task('b', '13:30', 60),
+    ], DATE, W, H);
+    expect(byId(out.bands, 'solo')).toMatchObject({ laneCount: 1, width: W, x: 0 });
+    expect(out.laneCount).toBe(2);
+  });
+
+  it('does not split back-to-back items — they share a lane', () => {
+    const out = layoutDayCell([task('a', '09:00', 60), task('b', '10:00', 60)], DATE, W, H);
+    expect(out.laneCount).toBe(1);
+    expect(out.bands.every((b) => b.width === W)).toBe(true);
+  });
+});
+
+describe('layoutDayCell — window clamping', () => {
+  it('clamps an item that starts before the window to the top edge', () => {
+    const out = layoutDayCell([task('early', '06:00', 120)], DATE, W, H);
+    expect(out.bands[0]).toMatchObject({ y: 0, height: 10, clampedStart: true, clampedEnd: false });
+  });
+
+  it('clamps an item that ends after the window to the bottom edge', () => {
+    const out = layoutDayCell([task('late', '20:30', 90)], DATE, W, H);
+    expect(out.bands[0]).toMatchObject({ y: 135, height: 5, clampedStart: false, clampedEnd: true });
+  });
+
+  it('still shows an item entirely before the window, as a minimum band at the top', () => {
+    const out = layoutDayCell([task('dawn', '05:00', 60)], DATE, W, H);
+    expect(out.bands).toHaveLength(1);
+    expect(out.bands[0]).toMatchObject({ y: 0, height: minBandHeight, clampedStart: true });
+  });
+
+  it('still shows an item entirely after the window, as a minimum band at the bottom', () => {
+    const out = layoutDayCell([task('night', '22:00', 60)], DATE, W, H);
+    expect(out.bands).toHaveLength(1);
+    expect(out.bands[0]).toMatchObject({ y: H - minBandHeight, height: minBandHeight, clampedEnd: true });
+  });
+
+  it('never fits the window to the day: a late item leaves the window untouched', () => {
+    const quiet = layoutDayCell([task('a', '09:00', 60)], DATE, W, H);
+    const busy = layoutDayCell([task('a', '09:00', 60), task('z', '23:00', 30)], DATE, W, H);
+    expect(busy.window).toEqual(quiet.window);
+    expect(byId(busy.bands, 'a')).toMatchObject({ y: 20, height: 10 });
+  });
+
+  it('honours an explicit window option', () => {
+    const out = layoutDayCell([task('a', '09:00', 60)], DATE, W, 120, { window: { startHour: 8, endHour: 20 } });
+    expect(out.window).toEqual({ startMinutes: 480, endMinutes: 1200 });
+    expect(out.bands[0]).toMatchObject({ y: 10, height: 10 });
+  });
+});
+
+describe('layoutDayCell — all-day and points', () => {
+  it('lists an all-day item separately and leaves the timed bands alone', () => {
+    const out = layoutDayCell([
+      task('bday', null, null, { isAllDay: true, imported: true }),
+      task('a', '09:00', 60),
+    ], DATE, W, H);
+    expect(out.allDay).toEqual([{ id: 'bday', kind: 'event', completed: false }]);
+    expect(out.bands.map((b) => b.id)).toEqual(['a']);
+    expect(out.points).toEqual([]);
+  });
+
+  it('keys all-day on the flag, so a date-only line stamped 00:00 is not drawn at midnight', () => {
+    const out = layoutDayCell([task('obs', '00:00', 0, { isAllDay: true })], DATE, W, H);
+    expect(out.allDay.map((i) => i.id)).toEqual(['obs']);
+    expect(out.bands).toEqual([]);
+    expect(out.points).toEqual([]);
+  });
+
+  it('treats a missing start time as all-day', () => {
+    const out = layoutDayCell([task('nostart', null, 30)], DATE, W, H);
+    expect(out.allDay.map((i) => i.id)).toEqual(['nostart']);
+  });
+
+  it('renders a zero-duration item as a point at its minute, not a band', () => {
+    const out = layoutDayCell([task('dentist', '11:00', 0), task('due', '15:00', null)], DATE, W, H);
+    expect(out.bands).toEqual([]);
+    expect(out.points).toEqual([
+      { id: 'dentist', kind: 'task', completed: false, x: W / 2, y: 40, clamped: null },
+      { id: 'due', kind: 'task', completed: false, x: W / 2, y: 80, clamped: null },
+    ]);
+  });
+
+  it('clamps a point outside the window and says which way', () => {
+    const out = layoutDayCell([task('p1', '05:00', 0), task('p2', '23:00', 0)], DATE, W, H);
+    expect(byId(out.points, 'p1')).toMatchObject({ y: 0, clamped: 'before' });
+    expect(byId(out.points, 'p2')).toMatchObject({ y: H, clamped: 'after' });
+  });
+
+  it('keeps a point out of the lane count', () => {
+    const out = layoutDayCell([task('a', '09:00', 60), task('p', '09:30', 0)], DATE, W, H);
+    expect(out.laneCount).toBe(1);
+    expect(out.bands[0].width).toBe(W);
+  });
+});
+
+describe('layoutDayCell — lane cap', () => {
+  it('caps lanes at the constant and reports the hidden items instead of thinning', () => {
+    const items = [
+      task('a', '09:00', 60), task('b', '09:10', 50), task('c', '09:20', 40), task('d', '09:30', 30),
+    ];
+    const out = layoutDayCell(items, DATE, W, H);
+    expect(out.laneCount).toBe(maxLanes);
+    expect(out.overflow.lanesNeeded).toBe(4);
+    expect(out.overflow.hidden).toEqual(['d']);
+    expect(out.hasOverflow).toBe(true);
+    expect(out.bands.map((b) => b.id)).toEqual(['a', 'b', 'c']);
+    const laneWidth = (W - (maxLanes - 1) * laneGap) / maxLanes;
+    for (const b of out.bands) expect(b.width).toBeCloseTo(laneWidth);
+  });
+
+  it('respects a maxLanes override', () => {
+    const out = layoutDayCell([task('a', '09:00', 60), task('b', '09:30', 60)], DATE, W, H, { maxLanes: 1 });
+    expect(out.laneCount).toBe(1);
+    expect(out.bands.map((b) => b.id)).toEqual(['a']);
+    expect(out.overflow).toMatchObject({ lanesNeeded: 2, hidden: ['b'] });
+  });
+});
+
+describe('layoutDayCell — minimum band height', () => {
+  it('keeps a 15-minute item visible at the minimum height', () => {
+    const out = layoutDayCell([task('short', '09:00', 15)], DATE, W, H);
+    expect(out.bands[0]).toMatchObject({ y: 20, height: minBandHeight });
+  });
+
+  it('does not let consecutive minimum-height bands merge', () => {
+    const out = layoutDayCell([
+      task('a', '09:00', 15), task('b', '09:15', 15), task('c', '09:30', 15),
+    ], DATE, W, H);
+    expect(out.laneCount).toBe(1);
+    const [a, b, c] = ['a', 'b', 'c'].map((id) => byId(out.bands, id));
+    expect(a.y).toBe(20);
+    expect(b.y).toBeGreaterThanOrEqual(a.y + a.height + bandGap);
+    expect(c.y).toBeGreaterThanOrEqual(b.y + b.height + bandGap);
+    for (const band of out.bands) expect(band.height).toBeGreaterThanOrEqual(minBandHeight);
+    expectNoPixelCollisions(out.bands);
+    expect(out.overflow.crowded).toBe(false);
+  });
+
+  it('keeps pushed bands inside the cell, pulling the run back up from the bottom edge', () => {
+    const out = layoutDayCell([task('a', '20:30', 90), task('b', '22:30', 30)], DATE, W, H);
+    for (const band of out.bands) {
+      expect(band.y).toBeGreaterThanOrEqual(0);
+      expect(band.y + band.height).toBeLessThanOrEqual(H);
+    }
+    expectNoPixelCollisions(out.bands);
+    expect(out.overflow.crowded).toBe(false);
+  });
+
+  it('flags a cell that cannot fit its minimum bands as crowded rather than piling them up', () => {
+    const items = Array.from({ length: 6 }, (_, i) => task(`s${i}`, `20:${String(i * 5).padStart(2, '0')}`, 5));
+    const out = layoutDayCell(items, DATE, W, 12);
+    expect(out.overflow.crowded).toBe(true);
+    expect(out.hasOverflow).toBe(true);
+    for (const band of out.bands) {
+      expect(band.y).toBeGreaterThanOrEqual(0);
+      expect(band.y + band.height).toBeLessThanOrEqual(12);
+    }
+  });
+});
+
+describe('layoutDayCell — gutter', () => {
+  it('subtracts the gutter from the usable width and parks points in it', () => {
+    const out = layoutDayCell([task('a', '09:00', 60), task('p', '11:00', 0)], DATE, 60, H, { gutterWidth: 12 });
+    expect(out.gutterWidth).toBe(12);
+    expect(out.usableWidth).toBe(48);
+    expect(out.bands[0]).toMatchObject({ x: 0, width: 48 });
+    expect(out.points[0]).toMatchObject({ x: 54, y: 40 });
+  });
+
+  it('defaults to no gutter, with points centred on the cell', () => {
+    const out = layoutDayCell([task('p', '11:00', 0)], DATE, 60, H);
+    expect(out.usableWidth).toBe(60);
+    expect(out.points[0].x).toBe(30);
+  });
+});
+
+describe('layoutDayCell — item kinds and dates', () => {
+  it('derives kind from the agenda shape and honours an explicit routine tag', () => {
+    expect(dayCellItemKind(event('e', '09:00', 30))).toBe('event');
+    expect(dayCellItemKind(task('t', '09:00', 30))).toBe('task');
+    expect(dayCellItemKind(task('tc', '09:00', 30, { imported: true, isTaskCalendar: true }))).toBe('task');
+    expect(dayCellItemKind({ id: 'r', name: 'Lunch', startTime: '12:00', duration: 60, kind: 'routine' })).toBe('routine');
+    expect(dayCellItemKind({ id: 'x', kind: 'nonsense' })).toBe('task');
+  });
+
+  it('tags routines as bands like any other, marked by kind', () => {
+    const routines = tagKind([{ id: 'r', name: 'Lunch', startTime: '12:00', duration: 60, isAllDay: false, completed: false }], 'routine');
+    const out = layoutDayCell([task('a', '12:30', 30), ...routines], DATE, W, H);
+    expect(out.laneCount).toBe(2);
+    expect(byId(out.bands, 'r')).toMatchObject({ kind: 'routine', lane: 0, y: 50, height: 10 });
+    expect(byId(out.bands, 'a')).toMatchObject({ kind: 'task', lane: 1 });
+  });
+
+  it('ignores items dated another day and keeps undated routines', () => {
+    const out = layoutDayCell([
+      task('today', '09:00', 60),
+      task('tomorrow', '09:00', 60, { date: '2026-09-17' }),
+      { id: 'r', name: 'Gym', startTime: '18:30', duration: 60, kind: 'routine' },
+    ], DATE, W, H);
+    expect(out.bands.map((b) => b.id).sort()).toEqual(['r', 'today']);
+  });
+
+  it('echoes the cell it laid out', () => {
+    const out = layoutDayCell([], DATE, W, H, { gutterWidth: 8 });
+    expect(out).toMatchObject({ date: DATE, cellWidth: W, cellHeight: H, gutterWidth: 8, usableWidth: W - 8 });
+  });
+});
+
+describe('layoutDayCell — a realistically busy day (agenda-core fixture)', () => {
+  const { agenda, routines } = busyDayItems();
+  const items = [...agenda, ...tagKind(routines, 'routine')];
+  const out = layoutDayCell(items, FIXTURE_DATE, W, H);
+
+  it('sorts every item into the right collection', () => {
+    expect(out.allDay.map((i) => i.id).sort()).toEqual(['cal-bday', 't-expense']);
+    expect(out.points.map((p) => p.id)).toEqual(['t-dentist']);
+    expect(out.bands.map((b) => b.id).sort()).toEqual([
+      'cal-dinner', 'cal-interview', 'cal-team', 'ev-1on1', 'ev-standup',
+      'recurring-r-workshop-2026-09-16', 'ro-breakfast', 'ro-gym', 'ro-lunch',
+      'ro-run', 'ro-stretch', 'ro-wind', 't-call', 't-deep', 't-review',
+    ]);
+  });
+
+  it('tags kinds from the agenda shapes: projected and imported events, tasks, routines', () => {
+    const kinds = Object.fromEntries(out.bands.map((b) => [b.id, b.kind]));
+    expect(kinds['cal-team']).toBe('event');
+    expect(kinds['ev-standup']).toBe('event');
+    expect(kinds['t-deep']).toBe('task');
+    expect(kinds['recurring-r-workshop-2026-09-16']).toBe('task');
+    expect(kinds['ro-lunch']).toBe('routine');
+    expect(byId(out.allDay, 'cal-bday').kind).toBe('event');
+    expect(byId(out.allDay, 't-expense').kind).toBe('task');
+    expect(byId(out.bands, 'ro-run').completed).toBe(true);
+    expect(byId(out.bands, 't-call').completed).toBe(true);
+  });
+
+  it('packs the morning two deep and the early afternoon three deep, nothing hidden', () => {
+    expect(out.laneCount).toBe(3);
+    expect(out.overflow).toEqual({ lanesNeeded: 3, hidden: [], crowded: false });
+    expect(out.hasOverflow).toBe(false);
+    expect(byId(out.bands, 't-deep')).toMatchObject({ lane: 0, laneCount: 2 });
+    expect(byId(out.bands, 'ev-1on1')).toMatchObject({ lane: 1, laneCount: 2 });
+    expect(byId(out.bands, 't-call')).toMatchObject({ lane: 1, laneCount: 2 });
+    expect(byId(out.bands, 'cal-team')).toMatchObject({ lane: 0, laneCount: 3 });
+    expect(byId(out.bands, 't-review')).toMatchObject({ lane: 1, laneCount: 3 });
+    expect(byId(out.bands, 'cal-interview')).toMatchObject({ lane: 2, laneCount: 3 });
+    for (const id of ['ev-standup', 'ro-lunch', 'ro-stretch', 'recurring-r-workshop-2026-09-16', 'ro-gym']) {
+      expect(byId(out.bands, id)).toMatchObject({ laneCount: 1, width: W });
+    }
+  });
+
+  it('clamps the edges of the day and keeps the out-of-window routine visible', () => {
+    expect(byId(out.bands, 'ro-run')).toMatchObject({ y: 0, height: minBandHeight, clampedStart: true });
+    expect(byId(out.bands, 'cal-dinner')).toMatchObject({ clampedEnd: true });
+    expect(byId(out.bands, 'ro-wind')).toMatchObject({ clampedEnd: true, height: minBandHeight });
+    expect(byId(out.bands, 'ro-wind').y + minBandHeight).toBe(H);
+    expect(byId(out.points, 't-dentist')).toMatchObject({ y: 40, clamped: null });
+  });
+
+  it('keeps every band inside the cell with no pixel collisions', () => {
+    for (const band of out.bands) {
+      expect(band.y).toBeGreaterThanOrEqual(0);
+      expect(band.y + band.height).toBeLessThanOrEqual(H);
+      expect(band.x).toBeGreaterThanOrEqual(0);
+      expect(band.x + band.width).toBeLessThanOrEqual(W + 1e-9);
+      expect(band.height).toBeGreaterThanOrEqual(minBandHeight);
+    }
+    expectNoPixelCollisions(out.bands);
+  });
+
+  it('lays out the same day identically with a desktop gutter, minus the gutter width', () => {
+    const desk = layoutDayCell(items, FIXTURE_DATE, W + 10, H, { gutterWidth: 10 });
+    expect(desk.usableWidth).toBe(W);
+    expect(desk.bands).toEqual(out.bands);
+    expect(desk.points[0]).toMatchObject({ x: W + 5, y: 40 });
+    expect(desk.allDay).toEqual(out.allDay);
+  });
+});

--- a/src/utils/monthCellLayout.test.js
+++ b/src/utils/monthCellLayout.test.js
@@ -180,6 +180,19 @@ describe('layoutDayCell — all-day and points', () => {
     ]);
   });
 
+  it('treats any non-positive, missing, or non-numeric duration as a point, outside lane packing', () => {
+    const out = layoutDayCell([
+      task('a', '09:00', 60), task('b', '09:30', 60),
+      task('zero', '09:15', 0), task('missing', '09:15', undefined),
+      task('nan', '09:15', NaN), task('neg', '09:15', -30), task('str', '09:15', 'soon'),
+    ], DATE, W, H);
+    expect(out.points.map((p) => p.id).sort()).toEqual(['missing', 'nan', 'neg', 'str', 'zero']);
+    expect(out.points.every((p) => p.y === 22.5)).toBe(true);
+    expect(out.bands.map((b) => b.id)).toEqual(['a', 'b']);
+    expect(out.laneCount).toBe(2);
+    expect(out.overflow).toEqual({ lanesNeeded: 2, hidden: [], crowded: false });
+  });
+
   it('clamps a point outside the window and says which way', () => {
     const out = layoutDayCell([task('p1', '05:00', 0), task('p2', '23:00', 0)], DATE, W, H);
     expect(byId(out.points, 'p1')).toMatchObject({ y: 0, clamped: 'before' });


### PR DESCRIPTION
## Summary

Step 1 of the month view: a pure layout module with no React and no rendering. Nothing is wired into the UI.

`layoutDayCell(items, date, cellWidth, cellHeight, options)` in `src/utils/monthCellLayout.js` turns one day's agenda items and routines into pixel geometry for a miniature vertical-timeline cell:

- **bands** — timed items with a duration, packed into overlap lanes, each with `x, y, width, height`, the item id, and its `kind` (`event` / `task` / `routine`).
- **points** — items with a start time but no duration (a `y`, plus an `x` in the gutter when one is reserved).
- **allDay** — items with no time at all, for the renderer to pin under the date number.
- **laneCount** and **overflow** (`lanesNeeded`, `hidden` ids past the lane cap, `crowded` when the cell cannot fit its minimum-height bands).

Rules implemented: a fixed 07:00–21:00 window shared by every cell (never fitted to one day), edge clamping so out-of-window items stay visible, one full-width lane unless items genuinely overlap, a lane cap of 3 with overflow reported instead of thinner lanes, a minimum band height with collision separation so pushed bands never merge, routines tagged by kind, and an optional right-hand gutter subtracted from the usable width.

## Constants

`src/constants/monthView.js` exports the hour window, minimum band height, lane cap, lane gap and band gap as one frozen plain-data object (plus named exports), free of component code, so the Android widget can adopt the same numbers. The lane cap of 3 is justified there: three lanes in a ~48px phone cell are still ~15px bands, four become stripes, and 3 matches the day grid's existing drop rule.

## Reuse instead of reimplementation

The week view's own helper (`weekColConflictPos`) is a non-transitive, non-greedy variant, so it was not the right thing to extract. The cleanest existing packer was the Day Dial's `assignDialLanes` (sweep-line overlap clusters + first-fit lanes, per-cluster lane counts). It is now `assignLanes` in `src/utils/intervalLanes.js`, and three consumers share it:

- `dayDial.js` — `assignDialLanes` delegates to it (existing dial tests unchanged and green).
- `useTaskDerived.js` — both `calculateConflictPosition` and `wouldExceedMaxColumns` replaced their duplicated BFS-cluster + greedy-column code with it; each keeps its own tie-break sort, so rendering is unchanged.
- the new month layout.

Item types are agenda-core's `AgendaItem` and `RoutineItem`; `kind` is derived via agenda-core's `isCalendarEvent`, with routines tagged by the caller (`tagKind`).

## Tests

`monthCellLayout.test.js` covers: empty day; single item; two overlapping; three-way overlap; clamping at each window edge (partial and fully outside); all-day alongside timed (including the Obsidian `isAllDay` + `00:00` case); zero-duration points; more overlaps than the lane cap; minimum-height cases (visibility, no merging, bottom-edge pull-back, crowded flag); the gutter; kind derivation and date filtering. `monthCellLayout.fixture.js` builds a realistically busy day from raw app data through `buildAgenda` and `routinesForDate`. `intervalLanes.test.js` covers the shared packer.

Full suite: 253 files / 3478 tests green; `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx)_