### PR TITLE
DAY view: match MULTI's card layout and overlap packing

### DIFF
--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -34,30 +34,6 @@ function getTaskSlice(task, col, hourHeight, timeToMinutes) {
   };
 }
 
-function columnConflictPos(task, colTasks, timeToMinutes) {
-  const tStart = timeToMinutes(task.startTime || '0:00');
-  const tEnd = tStart + (task.duration || 0);
-
-  const peers = colTasks.filter(other => {
-    if (other.id === task.id) return false;
-    const oStart = timeToMinutes(other.startTime || '0:00');
-    const oEnd = oStart + (other.duration || 0);
-    return tStart < oEnd && tEnd > oStart;
-  });
-
-  if (peers.length === 0) return { left: '0%', width: '100%' };
-
-  const group = [task, ...peers].sort((a, b) => {
-    const diff = timeToMinutes(a.startTime || '0:00') - timeToMinutes(b.startTime || '0:00');
-    return diff !== 0 ? diff : String(a.id).localeCompare(String(b.id));
-  });
-
-  const idx = group.findIndex(t => t.id === task.id);
-  const total = group.length;
-  const pct = 100 / total;
-  return { left: `${idx * pct}%`, width: `${pct}%` };
-}
-
 // ── DayViewColumn ─────────────────────────────────────────────────────────────
 
 const DayViewColumn = ({ col, colIdx, hourHeight }) => {
@@ -70,6 +46,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     getTasksForDate,
     getTaskCalendarStyle,
     taskWidths, setTaskRef,
+    calculateConflictPosition,
     timeToMinutes,
     formatTime,
     handleRoutineResizeStart, handleTouchRoutineResizeStart,
@@ -367,7 +344,10 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             if (!slice) return null;
 
             const { top, height, clippedTop, clippedBottom } = slice;
-            const { left, width } = columnConflictPos(task, colTasks, timeToMinutes);
+            // Same lane packing as MULTI (TimeGrid): transitive overlap
+            // clusters with first-fit columns and MULTI's 2px card margins,
+            // instead of the per-task neighbour count DAY used to compute.
+            const conflictPos = calculateConflictPosition(task, colTasks);
 
             const isImported = task.imported;
             const isCalendarEvent = isImported && !task.isTaskCalendar;
@@ -418,7 +398,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                   height: `${height}px`,
                   ...(hasBars && taskOverlapsHG(task)
                     ? { left: '50%', right: 0, width: undefined }
-                    : { left, width }),
+                    : { left: conflictPos.left, right: conflictPos.right, width: conflictPos.width }),
                   ...(isCalendarEvent || task.isTaskCalendar ? taskCalStyle : {}),
                   visibility: isMeasured ? 'visible' : 'hidden',
                 }}

--- a/src/components/DayView.jsx
+++ b/src/components/DayView.jsx
@@ -69,6 +69,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
     taskContextMenu, setTaskContextMenu,
     getTasksForDate,
     getTaskCalendarStyle,
+    taskWidths, setTaskRef,
     timeToMinutes,
     formatTime,
     handleRoutineResizeStart, handleTouchRoutineResizeStart,
@@ -388,9 +389,17 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
             // on its last visible slice, at the real bottom of the task.
             const canResize = (!isImported || !!task.nativeEventId) && !isTablet && !clippedBottom;
 
+            // Same card rule as MULTI (TimeGrid): measure the rendered card
+            // and switch to the compact layout under 300px; stay hidden
+            // until the first measurement so the wide layout never flashes.
+            const taskWidth = taskWidths[task.id];
+            const isMeasured = taskWidth !== undefined;
+            const isNarrowWidth = taskWidth < 300;
+
             return (
               <div
                 key={`${task.id}-${col.startHour}`}
+                ref={setTaskRef(task.id)}
                 data-task-id={task.id}
                 data-ctx-menu
                 draggable={taskDraggable}
@@ -411,6 +420,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                     ? { left: '50%', right: 0, width: undefined }
                     : { left, width }),
                   ...(isCalendarEvent || task.isTaskCalendar ? taskCalStyle : {}),
+                  visibility: isMeasured ? 'visible' : 'hidden',
                 }}
                 onClick={(e) => e.stopPropagation()}
                 onContextMenu={(e) => {
@@ -433,7 +443,7 @@ const DayViewColumn = ({ col, colIdx, hourHeight }) => {
                 <TimelineTaskCardContent
                   task={task}
                   height={height}
-                  isNarrowWidth={false}
+                  isNarrowWidth={isNarrowWidth}
                   flipNotesPanel={(8 * hourHeight) - (top + height) < 200}
                 />
                 {clippedBottom && (


### PR DESCRIPTION
## Summary

Two fixes to `DayViewColumn`, as two commits, so DAY renders task cards the way MULTI does: same component, same content, same states, and the same lane packing.

**Commit 1, card layout.** DAY passed `isNarrowWidth={false}` to `TimelineTaskCardContent`, so every DAY card got the wide layout (inline action buttons plus the "start • N min" line) regardless of lane width. MULTI measures each card and switches to the compact layout under 300px. DAY now registers the card with `setTaskRef`, derives `isNarrowWidth` from `taskWidths`, and hides the card until first measurement, mirroring `TimeGrid`.

History for the next reader: DAY was switched to narrow on 2026-04-21 (beb02e0) and reverted the same morning (4b34587) citing a text-color regression. That regression was the DAY card container missing `text-white`, fixed separately in 797adb8. The revert reason no longer applies.

**Commit 2, lane geometry.** DAY's private `columnConflictPos` counted a task's direct neighbours and sized by sort index, never following the overlap chain or reusing a freed column, so chained overlaps collided. DAY now calls the context's `calculateConflictPosition` with the column's tasks, exactly as `TimeGrid` does. WEEK keeps its own copy; #1606 covers it.

## Measurements

Chromium at 1920px, three one-hour tasks on today. "Mutual" = 09:00 / 09:15 / 09:30 (all overlap); "chain" = 09:00 / 09:30 / 10:00 (only the middle overlaps both).

| Scenario | Before | After commit 1 | After commit 2 |
|---|---|---|---|
| Mutual, DAY lane width | 153.77px, wide layout | 153.77px, compact | 149.77px, compact |
| Mutual, MULTI lane width | 163.98px, compact | unchanged | unchanged |
| Chain, DAY | A 0–50%, B 33–66%, C 50–100%: A/B and B/C collide 76.9px | same collisions | A and C in column 0, B in column 1, 226.66px each, no collisions |
| Chain, MULTI | A and C column 0, B column 1, 248px, no collisions | unchanged | unchanged |
| Lone task, DAY | 461.33px, wide | 461.33px, wide | 457.33px, wide |
| Lone task, MULTI | 500px, wide | unchanged | unchanged |

The remaining ~10px per-lane difference between DAY and MULTI is structural: DAY's three 8-hour columns each carry a 64px hour gutter, where MULTI pays one.

## Verification

Full suite 3434 tests green, `npm run lint` clean. HyperGLANCE half-width override and resize handles untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx)_