### PR TITLE
WEEK view: pack overlapping chips with the shared conflict layout

### DIFF
--- a/src/components/WeekView.jsx
+++ b/src/components/WeekView.jsx
@@ -14,29 +14,6 @@ import { formatLocalizedDate } from '../utils/localeFormatting.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function weekColConflictPos(task, colTasks, timeToMinutes) {
-  const tStart = timeToMinutes(task.startTime || '0:00');
-  const tEnd = tStart + (task.duration || 0);
-
-  const peers = colTasks.filter(other => {
-    if (other.id === task.id) return false;
-    const oStart = timeToMinutes(other.startTime || '0:00');
-    const oEnd = oStart + (other.duration || 0);
-    return tStart < oEnd && tEnd > oStart;
-  });
-
-  if (peers.length === 0) return { left: '1px', right: '1px', width: undefined };
-
-  const group = [task, ...peers].sort((a, b) => {
-    const diff = timeToMinutes(a.startTime || '0:00') - timeToMinutes(b.startTime || '0:00');
-    return diff !== 0 ? diff : String(a.id).localeCompare(String(b.id));
-  });
-  const idx = group.findIndex(t => t.id === task.id);
-  const total = group.length;
-  const pct = 100 / total;
-  return { left: `calc(${idx * pct}% + 1px)`, width: `calc(${pct}% - 2px)`, right: undefined };
-}
-
 // ── Task popover ──────────────────────────────────────────────────────────────
 
 const WeekViewTaskPopover = ({ task, anchor, onClose }) => {
@@ -109,6 +86,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, startHour, onTaskCl
   const {
     darkMode, borderClass, cardBg,
     getTasksForDate, getTaskCalendarStyle,
+    calculateConflictPosition,
     timeToMinutes,
     setTaskContextMenu, setTimelineContextMenu,
     isTablet,
@@ -313,7 +291,9 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, startHour, onTaskCl
           const rawH = duration * hourHeight / 60;
           const chipH = Math.max(22, rawH);
           const chipTop = (taskStart - startMinute) * hourHeight / 60;
-          const { left, right, width } = weekColConflictPos(task, colTasks, timeToMinutes);
+          // Same lane packing as MULTI and DAY: transitive overlap clusters
+          // with first-fit columns, from the shared interval packer.
+          const conflictPos = calculateConflictPosition(task, colTasks);
 
           const isImported = task.imported;
           const isCalendarEvent = isImported && !task.isTaskCalendar;
@@ -342,7 +322,7 @@ const WeekViewColumn = ({ date, dateStr, colIdx, hourHeight, startHour, onTaskCl
                 height: `${chipH}px`,
                 ...(hasBars && taskOverlapsHG(task)
                   ? { left: '25%', right: '1px', width: undefined }
-                  : { left, right: width ? undefined : right, width }),
+                  : { left: conflictPos.left, right: conflictPos.right, width: conflictPos.width }),
                 ...(isCalendarEvent || task.isTaskCalendar ? taskCalStyle : {}),
               }}
               onClick={(e) => {


### PR DESCRIPTION
## Summary

Closes #1606.

`WeekViewColumn` had its own `weekColConflictPos`: it counted a chip's direct neighbours and gave each member of that group an equal share by sort index, never following the overlap chain or reusing a freed column. For a chain (A 09:00–10:00, B 09:30–10:30, C 10:00–11:00) that put A at 0–50%, B at 33–66% and C at 50–100%, so A/B and B/C collided.

WEEK now calls `calculateConflictPosition` from context with the column's tasks and applies its `left` / `right` / `width`, the same path `TimeGrid` and (since #1607) `DayView` use. That function runs on the shared interval packer from #1605, so the day grid, mobile grid, Day Dial, DAY, and WEEK all pack overlaps the same way. Chips pick up MULTI's 2px margins in place of the old 1px, and its rule that read-only calendar events stay full width. The HyperGLANCE quarter-width override is untouched.

## Measurements

Chromium at 1920px, WEEK view, one-hour tasks on today, 215.42px day column. "Mutual" = 09:00 / 09:15 / 09:30; "chain" = 09:00 / 09:30 / 10:00.

| Scenario | Before | After |
|---|---|---|
| Mutual 3-way | 3 lanes, 69.8px each, no collisions | 3 lanes, 67.8px each, no collisions |
| Chain | A 0–50%, B 33–66%, C 50–100%; A/B and B/C collide 33.9px | A and C in column 0, B in column 1, 103.7px each, no collisions |
| Lone task | 213.42px (1px margins) | 211.42px (2px margins) |

## Verification

Full suite 3487 tests green, `npm run lint` clean. Net diff: 5 insertions, 25 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx)_