### PR TITLE
Bump version to 5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of the **GLANCE family**: focused, standalone apps connected through a shar
 [<img src="screenshots/badges/google-play.png" alt="Get it on Google Play" height="60">](https://play.google.com/store/apps/details?id=com.dayglance.app) [<img src="screenshots/badges/app-store.svg" alt="Download on the App Store" height="60">](https://apps.apple.com/app/id6771540599)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-5.0.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
+[![Version](https://img.shields.io/badge/version-5.1.0-green.svg)](https://github.com/krelltunez/dayglance/releases)
 
 [**Live App**](https://dayglance.app) · [**Documentation**](https://docs.dayglance.app) · [**Releases**](https://github.com/krelltunez/dayglance/releases)
 

--- a/dayglance-android/app/build.gradle.kts
+++ b/dayglance-android/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         // fallback for plain gradle/IDE builds and no longer needs a commit
         // per Play upload.
         versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 185
-        versionName = "5.0.0"
+        versionName = "5.1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayglance",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayglance",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "MIT",
       "dependencies": {
         "@glance-apps/agenda-core": "file:packages/agenda-core",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dayglance",
   "private": true,
   "license": "MIT",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "homepage": "https://dayglance.app",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary

Version bump for the 5.1.0 minor release, produced by `npm run bump 5.1.0` on top of current main (which already includes #1605, #1607 and #1608).

Rewritten, matching the 5.0.0 bump commit's shape:

- `package.json` version 5.0.0 → 5.1.0
- `package-lock.json` root version fields
- `dayglance-android/app/build.gradle.kts` `versionName`
- `README.md` shields.io version badge

The Obsidian bridge plugin has no non-test changes since 5.0.0 and stays at 0.9.0, so unlike the 5.0.0 bump no plugin files are touched. iOS `MARKETING_VERSION` and the Electron `CFBundleShortVersionString` derive from `package.json` at build time; the iOS project is generated (not tracked), so `npm run ios:generate` runs on the build machine after this merges, per RELEASING.md.

## What 5.1.0 carries since 5.0.0

- Day Dial batch, #1591–#1603: watch-face complications, focus sessions on the face, daylight band from solar elevation and UV, routines on their own track, all-day items, keyboard access and entry, completion subdial, date fit.
- iOS vault-config native mirror (#1588), late-observation gate (#1589), launch rollover keeps receipts (#1587).
- DAY view: MULTI's measured card layout and shared overlap packing (#1607).
- WEEK view: shared overlap packing (#1608, closes #1606).
- Month view step 1: headless day-cell layout engine and the shared interval lane packer (#1605).

## Verification

`npm run lint` clean, full suite 253 files / 3487 tests green on the bump commit.

## Release notes

Merge this last, then tag `v5.1.0` on the merge commit so the tag carries the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx)_