### PR TITLE
Date header opens the all-day new-task form in every view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7008,6 +7008,7 @@ const DayPlanner = () => {
     clearDeadline,
     addTask,
     openNewTaskForm,
+    openNewAllDayTask,
     openNewInboxTask,
     changeTaskColor,
     setTaskEnergy,
@@ -8606,7 +8607,7 @@ const DayPlanner = () => {
     dismissNlChip,
     buildSuggestions,
     manuallyScheduleTask, scheduleTaskAtNextSlot, scheduleDeadlineTaskAt, scheduleRoutineAt,
-    openNewTaskAtTime, openNewTaskForm, openNewInboxTask,
+    openNewTaskAtTime, openNewTaskForm, openNewAllDayTask, openNewInboxTask,
     recordDeletedTaskTombstone, parseRecurringId,
     expandMultiDayEvent,
 

--- a/src/components/CalendarHeader.jsx
+++ b/src/components/CalendarHeader.jsx
@@ -54,8 +54,6 @@ const CalendarHeader = () => {
     mobileDragTaskIdState,
     mobileDragPreviewDate,
     hoverTaskId, setHoverTaskId,
-    showAddTask, setShowAddTask,
-    newTask, setNewTask,
     dailyNotes,
     dailyNotesModalDate, setDailyNotesModalDate,
     taskWidths,
@@ -84,7 +82,7 @@ const CalendarHeader = () => {
     playUISound,
     pushUndo,
     setDragPreviewTime,
-    getNextQuarterHour,
+    openNewAllDayTask,
     addTasksFromSelection,
   } = useDayPlannerCtx();
   const { t } = useTranslation();
@@ -162,7 +160,9 @@ const CalendarHeader = () => {
   style={effectiveViewMode === 'day' ? { display: 'grid', gridTemplateColumns: `repeat(${dayViewColumns.length}, 1fr)` } : undefined}
 >
   {effectiveViewMode === 'sched' ? (
-    /* SCHED view: gutter cell + 7 clickable dates that set the agenda's starting day */
+    /* SCHED view: gutter cell + 7 clickable dates. Tapping one anchors the
+       agenda on that day AND opens the new-task form for it, all-day
+       pre-selected — the same date-header gesture as every other view. */
     <>
       <div
         className={`flex-shrink-0 border-r ${borderClass} flex items-center justify-center`}
@@ -177,11 +177,11 @@ const CalendarHeader = () => {
         return (
           <button
             key={dateStr}
-            onClick={() => goToDate(date)}
+            onClick={() => { goToDate(date); openNewAllDayTask(dateStr); }}
             className={`flex-1 flex items-center justify-center py-1.5 px-1 text-center transition-colors ${idx > 0 ? `border-l ${borderClass}` : ''}
               ${isSelected ? (darkMode ? 'bg-blue-900/40' : 'bg-blue-100') : isDateToday ? (darkMode ? 'bg-blue-900/20' : 'bg-blue-50') : ''}`}
             style={{ minHeight: 'var(--header-row-h)' }}
-            title={`Start agenda at ${dateStr}`}
+            title={`${t('task.addTask')}: ${t('task.allDay')}`}
           >
             <div className={`font-bold flex items-center justify-center gap-1.5 ${isDateToday || isSelected ? 'text-blue-600' : textPrimary}`}>
               <span>{formatLocalizedDate(date, { weekday: 'short' })}</span>
@@ -208,9 +208,11 @@ const CalendarHeader = () => {
         return (
           <div
             key={dateStr}
-            className={`flex-1 flex items-center justify-center py-1.5 px-1 text-center transition-colors ${idx > 0 ? `border-l ${borderClass}` : ''}
-              ${isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : ''}`}
+            className={`flex-1 flex items-center justify-center py-1.5 px-1 text-center cursor-pointer transition-colors ${idx > 0 ? `border-l ${borderClass}` : ''}
+              ${isDateToday ? (darkMode ? 'bg-blue-900/30 hover:bg-blue-900/50' : 'bg-blue-50 hover:bg-blue-100') : (darkMode ? 'hover:bg-gray-700' : 'hover:bg-stone-100')}`}
             style={{ minHeight: 'var(--header-row-h)' }}
+            onClick={() => openNewAllDayTask(dateStr)}
+            title={`${t('task.addTask')}: ${t('task.allDay')}`}
           >
             <div className={`font-bold flex items-center justify-center gap-1.5 ${isDateToday ? 'text-blue-600' : textPrimary}`}>
               <span>{formatLocalizedDate(date, { weekday: 'short' })}</span>
@@ -251,16 +253,7 @@ const CalendarHeader = () => {
         key={dateStr}
         className={`flex-1 py-2 px-3 text-center cursor-pointer hover:bg-opacity-80 transition-colors ${idx > 0 ? `border-l ${borderClass}` : ''} ${isDateToday ? (darkMode ? 'bg-blue-900/30 hover:bg-blue-900/50' : 'bg-blue-50 hover:bg-blue-100') : `${cardBg} ${darkMode ? 'hover:bg-gray-700' : 'hover:bg-stone-100'}`} ${isDragOverThis ? (darkMode ? 'bg-green-700 ring-2 ring-inset ring-green-400' : 'bg-green-200 ring-2 ring-inset ring-green-500') : ''}`}
         style={{ minHeight: 'var(--header-row-h)' }}
-        onClick={() => {
-          setNewTask({
-            title: '',
-            startTime: getNextQuarterHour(),
-            duration: 30,
-            date: dateStr,
-            isAllDay: true
-          });
-          setShowAddTask(true);
-        }}
+        onClick={() => openNewAllDayTask(dateStr)}
         onDragOver={(e) => { e.preventDefault(); if (autoScrollInterval.current) { clearInterval(autoScrollInterval.current); autoScrollInterval.current = null; } }}
         onDragEnter={(e) => {
           e.preventDefault();
@@ -330,12 +323,16 @@ const CalendarHeader = () => {
           onDragEnter={(e) => { e.preventDefault(); setDragOverAllDay(group.dateStr); setDragPreviewTime(null); }}
           onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) setDragOverAllDay(null); }}
           onDrop={(e) => handleDropOnDateHeader(e, group.date)}
-          title={draggedTask ? t('task.dropToAllDay') : ''}
+          onClick={() => openNewAllDayTask(group.dateStr)}
+          title={draggedTask ? t('task.dropToAllDay') : `${t('task.addTask')}: ${t('task.allDay')}`}
         >
           {/* ViewCycler floats in the absolute-left of the first date group so
               column boundaries align: both header and DayView start at x=0. */}
           {idx === 0 && (isTablet || canShowViewCycler) && (
-            <div className={`absolute left-0 top-0 w-16 h-full border-r ${borderClass} ${cardBg}`}>
+            <div
+              className={`absolute left-0 top-0 w-16 h-full border-r ${borderClass} ${cardBg} cursor-default`}
+              onClick={(e) => e.stopPropagation()}
+            >
               {isTablet && !isLandscape ? <MobileViewToggle /> : <ViewCycler />}
             </div>
           )}

--- a/src/components/MobileLayout.jsx
+++ b/src/components/MobileLayout.jsx
@@ -115,8 +115,6 @@ const MobileLayout = () => {
     showUntagged, setShowUntagged,
     showMobileTagFilter, setShowMobileTagFilter,
     allTags,
-    showAddTask, setShowAddTask,
-    newTask, setNewTask,
     showNewTaskDeadlinePicker, setShowNewTaskDeadlinePicker,
     taskContextMenu, setTaskContextMenu,
     timelineContextMenu, setTimelineContextMenu,
@@ -231,7 +229,7 @@ const MobileLayout = () => {
     handleNewTaskInputChange, handleNewTaskInputKeyDown, applySuggestionForNewTask,
     buildSuggestions,
     manuallyScheduleTask, scheduleTaskAtNextSlot,
-    openNewTaskAtTime, openNewTaskForm, openNewInboxTask,
+    openNewTaskAtTime, openNewTaskForm, openNewAllDayTask, openNewInboxTask,
     recordDeletedTaskTombstone, parseRecurringId,
     expandMultiDayEvent,
     getHourHeight, minutesToPosition, positionToMinutes, durationToHeight,
@@ -240,7 +238,7 @@ const MobileLayout = () => {
     getConflictingTasks, calculateConflictPosition, wouldExceedMaxColumns,
     filterByTags,
     getTasksForDate, getDateIndicators, hasTasksOnDate,
-    getDayName, getMonthDays, getNextQuarterHour,
+    getDayName, getMonthDays,
     weekStartDay,
     getTodayStr, getOverdueTasks,
     getTaskCalendarStyle,
@@ -755,16 +753,7 @@ const MobileLayout = () => {
                         <div
                           key={dateStr}
                           className={`flex-1 py-2 px-3 text-center ${idx > 0 ? `border-l ${borderClass}` : ''} ${mobileDragPreviewTime === 'all-day' ? (darkMode ? 'bg-blue-900/40' : 'bg-blue-100') : isDateToday ? (darkMode ? 'bg-blue-900/30' : 'bg-blue-50') : (darkMode ? 'bg-gray-700/50' : 'bg-stone-50')}`}
-                          onClick={() => {
-                            setNewTask({
-                              title: '',
-                              startTime: getNextQuarterHour(),
-                              duration: 30,
-                              date: dateStr,
-                              isAllDay: true
-                            });
-                            setShowAddTask(true);
-                          }}
+                          onClick={() => openNewAllDayTask(dateStr)}
                            title={`${t('task.addTask')}: ${t('task.allDay')}`}
                         >
                           <div className={`font-bold text-sm flex items-center justify-center gap-1.5 ${isDateToday ? 'text-blue-600' : textPrimary}`}>

--- a/src/hooks/useTaskActions.allDay.test.js
+++ b/src/hooks/useTaskActions.allDay.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import useTaskActions from './useTaskActions.js';
+
+// useTaskActions is a plain factory (no React hooks in its body), so it can be
+// called directly with just the deps the function under test touches.
+const buildActions = () => {
+  const setNewTask = vi.fn();
+  const setShowAddTask = vi.fn();
+  const setShowRecurrencePicker = vi.fn();
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { openNewAllDayTask } = useTaskActions({
+    setNewTask, setShowAddTask, setShowRecurrencePicker,
+  });
+  return { openNewAllDayTask, setNewTask, setShowAddTask, setShowRecurrencePicker };
+};
+
+describe('openNewAllDayTask — date-header tap in every view', () => {
+  it('opens the new-task form on the tapped date with All Day pre-selected', () => {
+    const { openNewAllDayTask, setNewTask, setShowAddTask } = buildActions();
+
+    openNewAllDayTask('2026-03-14');
+
+    expect(setNewTask).toHaveBeenCalledTimes(1);
+    const draft = setNewTask.mock.calls[0][0];
+    expect(draft.date).toBe('2026-03-14');
+    expect(draft.isAllDay).toBe(true);
+    expect(draft.title).toBe('');
+    expect(setShowAddTask).toHaveBeenCalledWith(true);
+  });
+
+  it('clears any recurrence carried over from a previous draft', () => {
+    const { openNewAllDayTask, setNewTask, setShowRecurrencePicker } = buildActions();
+
+    openNewAllDayTask('2026-03-14');
+
+    expect(setNewTask.mock.calls[0][0].recurrence).toBeNull();
+    expect(setShowRecurrencePicker).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/hooks/useTaskActions.js
+++ b/src/hooks/useTaskActions.js
@@ -312,6 +312,21 @@ export default function useTaskActions({
     setShowAddTask(true);
   };
 
+  // Date-header tap in every timeline view (MULTI/DAY/WEEK/SCHED and the
+  // mobile header): a new scheduled task on that day, "All Day" pre-selected.
+  const openNewAllDayTask = (dateStr) => {
+    setNewTask({
+      title: '',
+      startTime: getNextQuarterHour(),
+      duration: 30,
+      date: dateStr,
+      isAllDay: true,
+      recurrence: null
+    });
+    setShowRecurrencePicker(false);
+    setShowAddTask(true);
+  };
+
   const openNewInboxTask = () => {
     setNewTask({
       title: '',
@@ -885,6 +900,7 @@ export default function useTaskActions({
     // Create
     addTask,
     openNewTaskForm,
+    openNewAllDayTask,
     openNewInboxTask,
     // Update
     changeTaskColor,


### PR DESCRIPTION
## What

Tapping/clicking a date header now opens the "New Scheduled Task" modal for that date with **All Day** pre-selected, in **MULTI, DAY, WEEK and SCHED** alike (and on the mobile header).

## Why

The gesture only worked in MULTI and on the mobile header:

| View | Before | After |
| --- | --- | --- |
| MULTI | opens the form | unchanged |
| DAY | `cursor-pointer` but **no `onClick` at all** — a dead affordance | opens the form |
| WEEK | no cursor, no handler | opens the form, plus `cursor-pointer` and the hover tint the other headers have |
| SCHED | only re-anchored the agenda on that day | re-anchors **and** opens the form, so the agenda lands on the day being added to |
| mobile header | opens the form | unchanged |

## How

The two inline copies of the "build an all-day draft and show the form" block are replaced by one `openNewAllDayTask(dateStr)` in `useTaskActions`, exposed through the day-planner context and used by all four `CalendarHeader` branches and `MobileLayout`.

Two details fall out of having a single implementation:

- The draft now clears `recurrence` and closes the recurrence picker. The old MULTI/mobile copies omitted both, so a recurrence left over from a previous draft carried into the new all-day task — `openNewTaskForm` already did this.
- SCHED's hardcoded English `Start agenda at <date>` tooltip becomes the translated add-task tooltip the other views use.

In DAY the ViewCycler floats absolutely inside the first date group rather than in its own gutter cell, so its wrapper now stops click propagation — switching views must not also open the form. The header buttons that already stop propagation (daily note, focus log, habit rings) are unaffected.

## Tests

`src/hooks/useTaskActions.allDay.test.js` covers the new helper: the draft carries the tapped date with `isAllDay: true` and the form is shown, and a carried-over recurrence is cleared. Full suite: 254 files / 3489 tests passing; ESLint clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQAooF4qpSG8H5sSAcCUHt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQAooF4qpSG8H5sSAcCUHt)_