### PR TITLE
Dial: move the precipitation arc off the daylight band

### DIFF
--- a/src/components/DayDial.jsx
+++ b/src/components/DayDial.jsx
@@ -23,6 +23,7 @@ import {
   initialDialSelection,
   muteDialColor,
   padDialSegment,
+  precipArcSegments,
   precipRuns,
   stepDialSelection,
 } from '../utils/dayDial.js';
@@ -256,15 +257,22 @@ function SunMark({ min, kind }) {
 
 // Weather ring: hour temperatures as quiet monochrome numerals at the
 // 3-hour stations on an inner radius, and precipitation spells as a thin
-// arc hugging the band's inner edge — solid for rain, dashed for snow —
-// with one line glyph per spell at its center. Deliberately no per-hour
-// condition icons and no temperature color ramp: numbers stay data, the
-// palette stays the schedule's, and precipitation is the one condition
-// that earns ink. Temps sit at r=250, inside the needle's root (265), so
-// the moving element never crosses them.
+// arc — solid for rain, dashed for snow — broken at its midpoint for one
+// line glyph per spell. Deliberately no per-hour condition icons and no
+// temperature color ramp: numbers stay data, the palette stays the
+// schedule's, and precipitation is the one condition that earns ink. Temps
+// sit at r=250, inside the needle's root (265), so the moving element never
+// crosses them.
+//
+// The precipitation track sits at 274, centered in the only clear annulus
+// the face has left for it. Its floor is the temperature numerals: a
+// three-digit reading at a diagonal station throws its corner out to 267,
+// which is the number to beat, not the 250 they are centered on. Its
+// ceiling is the daylight band's inner edge at 282. Fifteen units, and the
+// glyph needs thirteen of them — hence one shared radius for track and
+// glyph, and a glyph scaled to leave a little over two units at each edge.
 const TEMP_R = 250;
-const PRECIP_ARC_R = 292;
-const PRECIP_GLYPH_R = 268;
+const PRECIP_R = 274;
 
 // Lucide 'droplet'; snow is three crossed one-weight lines (a 6-spoke
 // star) — lucide's snowflake is too dense at this size.
@@ -274,7 +282,7 @@ const SNOW_PATHS = 'M12 3v18 M4.2 7.5l15.6 9 M19.8 7.5l-15.6 9';
 
 function WeatherRing({ hourly }) {
   const runs = precipRuns(hourly);
-  const glyphScale = 0.55;
+  const glyphScale = 0.45;
   return (
     <g>
       {HOUR_LABELS.map(({ min }) => {
@@ -295,17 +303,20 @@ function WeatherRing({ hourly }) {
       })}
       {runs.map((run) => {
         const mid = (run.startMin + run.endMin) / 2;
-        const g = dialPoint(CX, CY, PRECIP_GLYPH_R, mid);
+        const g = dialPoint(CX, CY, PRECIP_R, mid);
         return (
           <g
             key={`${run.kind}-${run.startMin}`}
             stroke="#ffffff" strokeOpacity={0.3} fill="none" strokeLinecap="round"
           >
-            <path
-              d={dialArcPath(CX, CY, PRECIP_ARC_R, run.startMin + 4, run.endMin - 4)}
-              strokeWidth={2.5}
-              strokeDasharray={run.kind === 'snow' ? '2 7' : undefined}
-            />
+            {precipArcSegments(run).map(([from, to]) => (
+              <path
+                key={from}
+                d={dialArcPath(CX, CY, PRECIP_R, from, to)}
+                strokeWidth={2.5}
+                strokeDasharray={run.kind === 'snow' ? '2 7' : undefined}
+              />
+            ))}
             <g
               strokeWidth={2.6} strokeLinejoin="round"
               transform={`translate(${(g.x - 12 * glyphScale).toFixed(2)} ${(g.y - 12 * glyphScale).toFixed(2)}) scale(${glyphScale})`}

--- a/src/utils/dayDial.js
+++ b/src/utils/dayDial.js
@@ -747,3 +747,32 @@ export function dialLabelYieldsToSun(labelMin, sun) {
     return Math.min(d, DIAL_DAY_MINUTES - d) < SUN_LABEL_CLEARANCE_MIN;
   });
 }
+
+// A precipitation run's arc is broken around the glyph that marks it, and the
+// two share one radius. Stacking them at separate radii is not an option: the
+// only clear annulus between the temperature numerals and the daylight band's
+// inner edge is about 15 units, and the glyph alone needs 13 of it.
+export const PRECIP_INSET_MIN = 4;
+export const PRECIP_GAP_MIN = 14;
+export const PRECIP_MIN_STUB_MIN = 6;
+
+/**
+ * The drawable segments of a precipitation run's arc: the run, inset at both
+ * ends, with a gap opened at its midpoint for the glyph — the way a
+ * chronograph scale breaks around its markers rather than running under them.
+ *
+ * Returns [[startMin, endMin], ...] — two stubs normally, or none when the run
+ * is too short to leave a visible stub on either side, in which case the glyph
+ * carries the mark by itself.
+ */
+export function precipArcSegments(run, {
+  inset = PRECIP_INSET_MIN,
+  gap = PRECIP_GAP_MIN,
+  minStub = PRECIP_MIN_STUB_MIN,
+} = {}) {
+  const from = run.startMin + inset;
+  const to = run.endMin - inset;
+  const mid = (run.startMin + run.endMin) / 2;
+  const segments = [[from, mid - gap / 2], [mid + gap / 2, to]];
+  return segments.every(([s, e]) => e - s >= minStub) ? segments : [];
+}

--- a/src/utils/dayDial.test.js
+++ b/src/utils/dayDial.test.js
@@ -19,6 +19,7 @@ import {
   findDialFocusBlock,
   initialDialSelection,
   muteDialColor,
+  precipArcSegments,
   precipRuns,
   stepDialSelection,
   computeDaylightBand,
@@ -427,6 +428,33 @@ describe('muteDialColor', () => {
     expect(muteDialColor('not-a-color')).toBe('#93c5fd');
     expect(muteDialColor(null)).toBe('#93c5fd');
     expect(muteDialColor('#abc')).toBe('#93c5fd'); // shorthand unsupported
+  });
+});
+
+describe('precipArcSegments', () => {
+  it('brackets the glyph with a stub on each side', () => {
+    // 15:00-18:00 of rain: inset 4 at both ends, 14 minutes opened at 16:30.
+    expect(precipArcSegments({ startMin: 900, endMin: 1080 })).toEqual([
+      [904, 983], [997, 1076],
+    ]);
+  });
+
+  it('leaves the shortest run precipRuns can produce a visible stub', () => {
+    // One wet hour is the floor: the runs are hour-grained.
+    const [left, right] = precipArcSegments({ startMin: 900, endMin: 960 });
+    expect(left[1] - left[0]).toBeGreaterThanOrEqual(6);
+    expect(right[1] - right[0]).toBeGreaterThanOrEqual(6);
+  });
+
+  it('drops the arc when a stub would be too short to read', () => {
+    // Not reachable from precipRuns today, but the glyph has to be able to
+    // stand alone rather than sprout two specks either side of it.
+    expect(precipArcSegments({ startMin: 900, endMin: 930 })).toEqual([]);
+  });
+
+  it('keeps the gap centered on the run, so the glyph marks its middle', () => {
+    const [left, right] = precipArcSegments({ startMin: 600, endMin: 780 });
+    expect(690 - left[1]).toBe(right[0] - 690);
   });
 });
 


### PR DESCRIPTION
The precipitation arc sat at `r=292`, dead centre of the daylight band's `[282, 302]`. The arc predates the band, and nothing in a sandbox with no egress could render both at once, so the collision only surfaced once the README capture started serving the forecast from a fixture.

### Moving it inward isn't just a smaller radius

Measured against a real render rather than reasoned from the constants:

| | radial reach |
|---|---|
| Temperature numerals, centred on 250 | ink corner of a **3-digit** reading at a diagonal station: **267** |
| Daylight band, inner edge | **282** |
| **Clear annulus** | **15 units** |
| Precip glyph (0.55 scale) needs | **13 units** |

The numerals are the floor, and 267 is the number to beat, not the 250 they're centred on: `100°` is 31.6 units of ink wide, and at a 45° station its corner points straight out. That leaves no room to stack the arc and the glyph at separate radii — which is exactly what the old `292` / `268` split was doing, by borrowing the band's space for the arc.

### So they share one radius and the arc breaks around the glyph

`PRECIP_R = 274`, centred in the clear annulus, with a 14-minute gap opened at the run's midpoint for the glyph — the way a chronograph scale breaks around its markers rather than running under them. The glyph drops to 0.45 scale, which buys **2.5 units** of clearance to the numerals and **3.4** to the band (both measured on the render, not computed).

The segment maths is a pure function, `precipArcSegments`, with tests: two stubs normally, none when a run is too short to leave a readable stub either side, in which case the glyph stands alone. The shortest run `precipRuns` can emit is one hour, which still yields a 19-minute stub on each side.

**The daylight band is untouched** — no constant, colour or feather changed.

Suite green: 254 files / 3493 tests (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lj8Pw3MBmbEvYPSWLSHnPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj8Pw3MBmbEvYPSWLSHnPS)_