### PR TITLE
Month view: day cell component (step 2, additive)

### DIFF
--- a/src/components/month/MonthCellDevHarness.jsx
+++ b/src/components/month/MonthCellDevHarness.jsx
@@ -1,0 +1,105 @@
+// ┌──────────────────────────────────────────────────────────────────────────┐
+// │ TEMPORARY. Month view step 2 dev harness for MonthDayCell.               │
+// │ Not linked from the app. Reach it with `?month-cells` on the web or the  │
+// │ Electron dev server, or on a device by setting localStorage             │
+// │ 'day-planner-dev-month-cells' to '1' (chrome://inspect on a debug       │
+// │ Android build) and reloading. Delete this file and the gate in           │
+// │ src/main.jsx once the month grid (step 3) renders real cells.            │
+// └──────────────────────────────────────────────────────────────────────────┘
+import React, { useEffect, useState } from 'react';
+import MonthDayCell from './MonthDayCell.jsx';
+import { tagKind } from '../../utils/monthCellLayout.js';
+import { FIXTURE_DATE, busyDayItems } from '../../utils/monthCellLayout.fixture.js';
+
+const D = FIXTURE_DATE;
+const task = (id, startTime, duration, extra = {}) => ({ id, title: id, date: D, startTime, duration, isAllDay: false, completed: false, ...extra });
+const event = (id, startTime, duration, extra = {}) => task(id, startTime, duration, { imported: true, ...extra });
+const busy = busyDayItems();
+
+const SCENARIOS = [
+  { label: 'empty', items: [] },
+  { label: 'single', items: [task('a', '09:00', 60)] },
+  { label: '3-way', items: [event('team', '13:00', 60), task('review', '13:30', 60), event('interview', '13:45', 30)] },
+  { label: 'past cap', items: [task('a', '09:00', 60), task('b', '09:10', 50), event('c', '09:20', 40), task('d', '09:30', 30)] },
+  { label: 'all-day + timed', items: [
+    task('bday', null, null, { isAllDay: true, imported: true }),
+    task('expense', null, null, { isAllDay: true }),
+    { id: 'dl-1', kind: 'deadline', isAllDay: true, completed: false, date: D },
+    ...tagKind([{ id: 'r-ad', name: 'Stretch', startTime: null, duration: null, isAllDay: true, completed: false }], 'routine'),
+    task('a', '10:00', 60), event('e', '14:00', 30, { completed: true }),
+  ] },
+  { label: 'point', items: [task('dentist', '11:00', 0), event('call', '15:30', 0), task('a', '09:00', 90)] },
+  { label: 'busy', items: [...busy.agenda, ...tagKind(busy.routines, 'routine'), { id: 'dl-2', kind: 'deadline', isAllDay: true, completed: false, date: D }] },
+];
+
+const SIZES = [
+  { label: 'phone 52×88, no gutter', width: 52, height: 88, gutterWidth: 0 },
+  { label: 'phone 56×110, no gutter', width: 56, height: 110, gutterWidth: 0 },
+  { label: 'tablet 96×120, gutter 12', width: 96, height: 120, gutterWidth: 12 },
+  { label: 'desktop 160×140, gutter 16', width: 160, height: 140, gutterWidth: 16 },
+  { label: 'wide 220×200, gutter 20', width: 220, height: 200, gutterWidth: 20 },
+];
+
+const Row = ({ size, dark }) => (
+  <section className="mb-6">
+    <h2 className="text-xs font-semibold text-stone-500 dark:text-gray-400 mb-1">{size.label}</h2>
+    <div className="flex flex-wrap gap-3 items-start">
+      {SCENARIOS.map((sc, i) => (
+        <figure key={sc.label} className="m-0">
+          <div className={`border ${dark ? 'border-gray-700 bg-gray-900' : 'border-stone-300 bg-white'}`} style={{ width: size.width, height: size.height }}>
+            <MonthDayCell date={D} items={sc.items} width={size.width} height={size.height} gutterWidth={size.gutterWidth}
+              isToday={i === 1} inMonth={i !== 0} onSelect={(d) => console.log('[month-cells] select', d, sc.label)} />
+          </div>
+          <figcaption className="text-[10px] text-stone-500 dark:text-gray-500 mt-0.5">{sc.label}</figcaption>
+        </figure>
+      ))}
+    </div>
+  </section>
+);
+
+// Seven columns across the real viewport, the shape the step 3 grid will have:
+// gutter on wide screens (the app's tablet breakpoint), none on phones.
+const FitRow = ({ dark }) => {
+  const [vw, setVw] = useState(() => window.innerWidth);
+  useEffect(() => {
+    const onResize = () => setVw(window.innerWidth);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+  const width = Math.floor((vw - 16) / 7);
+  const gutterWidth = vw >= 721 ? 14 : 0;
+  const height = vw >= 721 ? 140 : 96;
+  return (
+    <section className="mb-6">
+      <h2 className="text-xs font-semibold text-stone-500 dark:text-gray-400 mb-1">fit to screen: 7 × {width}×{height}, gutter {gutterWidth}</h2>
+      <div className={`grid border-t border-l ${dark ? 'border-gray-700' : 'border-stone-300'}`} style={{ gridTemplateColumns: `repeat(7, ${width}px)` }}>
+        {SCENARIOS.map((sc, i) => (
+          <div key={sc.label} className={`border-r border-b ${dark ? 'border-gray-700' : 'border-stone-300'}`}>
+            <MonthDayCell date={D} items={sc.items} width={width} height={height} gutterWidth={gutterWidth} isToday={i === 6} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default function MonthCellDevHarness() {
+  const [dark, setDark] = useState(() => document.documentElement.classList.contains('dark'));
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark);
+    document.documentElement.style.colorScheme = dark ? 'dark' : 'light';
+  }, [dark]);
+  return (
+    <main className={`min-h-screen p-2 ${dark ? 'bg-gray-950 text-gray-100' : 'bg-stone-50 text-stone-900'}`}>
+      <header className="flex items-center gap-3 mb-4">
+        <h1 className="text-sm font-bold">Month day cells (TEMPORARY dev harness)</h1>
+        <button type="button" onClick={() => setDark((v) => !v)} className="text-xs px-2 py-1 rounded border border-current">
+          {dark ? 'light' : 'dark'}
+        </button>
+        <span className="text-[10px] text-stone-500 dark:text-gray-500">cells: 1st is outside the month, 2nd is today; last row is today</span>
+      </header>
+      <FitRow dark={dark} />
+      {SIZES.map((size) => <Row key={size.label} size={size} dark={dark} />)}
+    </main>
+  );
+}

--- a/src/components/month/MonthDayCell.jsx
+++ b/src/components/month/MonthDayCell.jsx
@@ -1,0 +1,202 @@
+import React, { useId } from 'react';
+import { layoutDayCell } from '../../utils/monthCellLayout.js';
+import { MONTH_CELL_LAYOUT } from '../../constants/monthView.js';
+
+// Month view day cell (step 2). A miniature vertical timeline: the layout
+// engine (utils/monthCellLayout.js) decides where everything goes, this
+// component only draws it. There is no text in a cell beyond the date
+// number and an overflow count, no hover state on anything, and the whole
+// cell is the one tap target. Desktop and phone share the encoding; only the
+// gutter (present when gutterWidth > 0) and the pixels-per-hour vary.
+//
+// Encoding, chosen so nothing rests on colour alone:
+//   task     solid band, app blue
+//   event    outlined band with a diagonal hatch, app gray
+//   routine  solid band drawn faint, app teal
+//   point    hollow diamond at the minute, stroked in the kind's colour
+//   all-day  small marks with NO vertical meaning: stacked top-down in the
+//            gutter in a fixed order (deadline, event, task, routine), or
+//            in a row beside the date number when there is no gutter
+//   deadline a flag mark, app rose, all-day only
+// Colours are the app's Tailwind tokens with dark: variants, so the cell
+// follows the root `dark` class like everything else.
+
+const ALL_DAY_ORDER = ['deadline', 'event', 'task', 'routine'];
+const orderAllDay = (list) => [...list].sort((a, b) =>
+  ALL_DAY_ORDER.indexOf(a.kind) - ALL_DAY_ORDER.indexOf(b.kind) || Number(a.completed) - Number(b.completed));
+
+const STROKE = {
+  task: 'stroke-blue-500 dark:stroke-blue-400',
+  event: 'stroke-gray-500 dark:stroke-gray-400',
+  routine: 'stroke-teal-600 dark:stroke-teal-500',
+  deadline: 'stroke-rose-500 dark:stroke-rose-400',
+};
+const FILL = {
+  task: 'fill-blue-500 dark:fill-blue-400',
+  event: 'fill-gray-200 dark:fill-gray-700',
+  routine: 'fill-teal-600 dark:fill-teal-500',
+  deadline: 'fill-rose-500 dark:fill-rose-400',
+};
+const dim = (completed) => (completed ? 'opacity-50' : '');
+
+/** One timed band. Events get the outline + hatch, routines the faint fill. */
+function Band({ band, hatchId }) {
+  const { kind, x, y, width, height, completed } = band;
+  const common = { 'data-band': band.id, 'data-kind': kind };
+  if (kind === 'event') {
+    return (
+      <g {...common} className={dim(completed)}>
+        <rect x={x + 0.5} y={y + 0.5} width={Math.max(0, width - 1)} height={Math.max(0, height - 1)} rx={1}
+          strokeWidth={1} className={`${FILL.event} ${STROKE.event}`} />
+        <rect x={x + 1} y={y + 1} width={Math.max(0, width - 2)} height={Math.max(0, height - 2)} fill={`url(#${hatchId})`} />
+      </g>
+    );
+  }
+  const faint = kind === 'routine' ? 'opacity-30' : '';
+  return (
+    <rect {...common} x={x} y={y} width={width} height={height} rx={1}
+      className={`${FILL[kind] || FILL.task} ${faint} ${dim(completed)}`} />
+  );
+}
+
+/** A moment with no length: a hollow diamond, so it never reads as a short band. */
+function Point({ point, x }) {
+  const s = MONTH_CELL_LAYOUT.pointSize;
+  const { y, kind, completed } = point;
+  return (
+    <path data-point={point.id} data-kind={kind}
+      d={`M${x},${y - s} L${x + s},${y} L${x},${y + s} L${x - s},${y} Z`}
+      strokeWidth={1.25} className={`fill-white dark:fill-gray-900 ${STROKE[kind] || STROKE.task} ${dim(completed)}`} />
+  );
+}
+
+/** An all-day mark. Position is the caller's; it carries no time. */
+function AllDayMark({ item, x, y, hatchId }) {
+  const m = MONTH_CELL_LAYOUT.gutterMarkerSize;
+  const common = { 'data-allday-marker': item.id, 'data-kind': item.kind, className: dim(item.completed) };
+  if (item.kind === 'deadline') {
+    // A flag: pole on the left, pennant to the right.
+    return (
+      <g {...common}>
+        <path d={`M${x + 1},${y} v${m}`} strokeWidth={1.25} className={STROKE.deadline} />
+        <path d={`M${x + 1},${y} h${m - 1} l-2,${m / 2 - 0.5} l2,${m / 2 - 0.5} h${-(m - 1)} Z`} className={FILL.deadline} />
+      </g>
+    );
+  }
+  if (item.kind === 'event') {
+    return (
+      <g {...common}>
+        <rect x={x + 0.5} y={y + 0.5} width={m - 1} height={m - 1} strokeWidth={1} className={`${FILL.event} ${STROKE.event}`} />
+        <rect x={x + 1} y={y + 1} width={m - 2} height={m - 2} fill={`url(#${hatchId})`} />
+      </g>
+    );
+  }
+  const faint = item.kind === 'routine' ? 'opacity-40' : '';
+  return <rect {...common} x={x} y={y} width={m} height={m} rx={1} className={`${FILL[item.kind] || FILL.task} ${faint} ${dim(item.completed)}`} />;
+}
+
+/**
+ * @param {object} props
+ * @param {string} props.date          YYYY-MM-DD
+ * @param {Array<object>} props.items  AgendaItem / RoutineItem shapes for the day,
+ *   routines tagged kind 'routine' and deadlines tagged kind 'deadline' (see tagKind)
+ * @param {number} props.width         measured cell width, px
+ * @param {number} props.height        measured cell height, px
+ * @param {number} [props.gutterWidth=0]  right-hand all-day track; 0 on narrow cells
+ * @param {boolean} [props.isToday=false]
+ * @param {boolean} [props.inMonth=true]  false dims the cell (adjacent month)
+ * @param {string} [props.label]       accessible name; defaults to the date
+ * @param {(date: string) => void} [props.onSelect]  the whole-cell tap; the
+ *   day sheet it opens is step 4, so callers leave it unwired for now
+ */
+export default function MonthDayCell({
+  date, items, width, height, gutterWidth = 0, isToday = false, inMonth = true, label, onSelect,
+}) {
+  const hatchId = `mdc-hatch-${useId().replace(/:/g, '')}`;
+  const { headerHeight, gutterMarkerSize: m, gutterMarkerGap: g } = MONTH_CELL_LAYOUT;
+  const timelineHeight = Math.max(0, height - headerHeight);
+  const layout = layoutDayCell(items, date, width, timelineHeight, { gutterWidth });
+  const { usableWidth, bands, points, overflow } = layout;
+  const hasGutter = layout.gutterWidth > 0;
+  const allDay = orderAllDay(layout.allDay);
+  const dayNumber = Number(String(date).slice(8, 10)) || '';
+
+  // All-day marks: stacked in the gutter, or a row in the header. Whatever
+  // does not fit joins the overflow count instead of being drawn smaller.
+  const gutterCapacity = hasGutter ? Math.max(0, Math.floor((timelineHeight - 2 + g) / (m + g))) : 0;
+  const headerCapacity = hasGutter ? 0 : Math.max(0, Math.floor((width - headerHeight - 6 + g) / (m + g)));
+  const capacity = hasGutter ? gutterCapacity : headerCapacity;
+  const shownAllDay = allDay.slice(0, capacity);
+  const overflowCount = overflow.hidden.length + (allDay.length - shownAllDay.length);
+  const showOverflow = overflowCount > 0 || overflow.crowded;
+  const overflowText = overflowCount > 0 ? `+${overflowCount}` : '+';
+  const badgeW = 6 + 5 * overflowText.length;
+
+  return (
+    <button
+      type="button"
+      data-month-cell={date}
+      data-today={isToday ? 'true' : undefined}
+      data-in-month={inMonth ? 'true' : 'false'}
+      aria-label={label || date}
+      onClick={onSelect ? () => onSelect(date) : undefined}
+      className={`relative block p-0 m-0 border-0 bg-transparent text-left select-none appearance-none cursor-pointer overflow-hidden
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500
+        ${isToday ? 'bg-blue-50 dark:bg-blue-900/20' : ''} ${inMonth ? '' : 'opacity-40'}`}
+      style={{ width, height }}
+    >
+      <div className="absolute top-0 left-0 right-0 flex items-center gap-1 px-[3px]" style={{ height: headerHeight }}>
+        <span
+          data-month-cell-date
+          className={`inline-flex items-center justify-center text-[11px] font-semibold leading-none tabular-nums shrink-0
+            ${isToday ? 'bg-blue-600 text-white rounded-full' : 'text-stone-700 dark:text-gray-200'}`}
+          style={{ width: headerHeight - 4, height: headerHeight - 4 }}
+        >
+          {dayNumber}
+        </span>
+        {!hasGutter && shownAllDay.length > 0 && (
+          <svg data-month-cell-allday-row width={shownAllDay.length * (m + g) - g} height={m} aria-hidden="true" className="shrink-0">
+            {shownAllDay.map((item, i) => <AllDayMark key={item.id} item={item} x={i * (m + g)} y={0} hatchId={hatchId} />)}
+          </svg>
+        )}
+      </div>
+
+      <svg
+        data-month-cell-timeline
+        width={width}
+        height={timelineHeight}
+        viewBox={`0 0 ${width} ${timelineHeight}`}
+        aria-hidden="true"
+        className="absolute left-0 block"
+        style={{ top: headerHeight }}
+      >
+        <defs>
+          <pattern id={hatchId} patternUnits="userSpaceOnUse" width="4" height="4" patternTransform="rotate(45)"
+            className="text-gray-500 dark:text-gray-400">
+            <line x1="0" y1="0" x2="0" y2="4" stroke="currentColor" strokeWidth="1" />
+          </pattern>
+        </defs>
+
+        {hasGutter && (
+          <g data-month-cell-gutter>
+            <rect x={usableWidth} y={0} width={layout.gutterWidth} height={timelineHeight} className="fill-stone-100 dark:fill-white/5" />
+            <line x1={usableWidth + 0.5} y1={0} x2={usableWidth + 0.5} y2={timelineHeight} strokeWidth={1} className="stroke-stone-300 dark:stroke-white/15" />
+            {shownAllDay.map((item, i) => (
+              <AllDayMark key={item.id} item={item} x={usableWidth + (layout.gutterWidth - m) / 2} y={2 + i * (m + g)} hatchId={hatchId} />
+            ))}
+          </g>
+        )}
+
+        {bands.map((band) => <Band key={band.id} band={band} hatchId={hatchId} />)}
+        {points.map((point) => <Point key={point.id} point={point} x={usableWidth - MONTH_CELL_LAYOUT.pointSize - 2} />)}
+
+        {showOverflow && (
+          <g data-month-cell-overflow={overflowText} transform={`translate(${Math.max(0, usableWidth - badgeW - 1)}, ${Math.max(0, timelineHeight - 12)})`}>
+            <rect width={badgeW} height={11} rx={3} className="fill-stone-700 dark:fill-gray-200" />
+            <text x={badgeW / 2} y={8.5} textAnchor="middle" fontSize="8" fontWeight="600" className="fill-white dark:fill-gray-900">{overflowText}</text>
+          </g>
+        )}
+      </svg>
+    </button>
+  );
+}

--- a/src/components/month/MonthDayCell.test.jsx
+++ b/src/components/month/MonthDayCell.test.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import MonthDayCell from './MonthDayCell.jsx';
+import { tagKind } from '../../utils/monthCellLayout.js';
+
+// Static markup, no DOM (the repo has no jsdom). These pin what the cell
+// RENDERS for each collection the layout returns; the geometry itself is
+// step 1's and covered in utils/monthCellLayout.test.js.
+
+const DATE = '2026-09-16';
+const task = (id, startTime, duration, extra = {}) =>
+  ({ id, title: `Title of ${id}`, date: DATE, startTime, duration, isAllDay: false, completed: false, ...extra });
+const event = (id, startTime, duration, extra = {}) => task(id, startTime, duration, { imported: true, ...extra });
+const render = (props) => renderToStaticMarkup(<MonthDayCell date={DATE} width={160} height={140} gutterWidth={16} {...props} />);
+const count = (html, re) => (html.match(re) || []).length;
+const visibleText = (html) => html.replace(/<[^>]+>/g, '').trim();
+
+describe('MonthDayCell', () => {
+  it('renders an empty day as just the date number', () => {
+    const html = render({ items: [] });
+    expect(html).toContain('data-month-cell="2026-09-16"');
+    expect(html).toContain('data-month-cell-date');
+    expect(visibleText(html)).toBe('16');
+    expect(html).not.toContain('data-band=');
+    expect(html).not.toContain('data-point=');
+    expect(html).not.toContain('data-allday-marker=');
+    expect(html).not.toContain('data-month-cell-overflow');
+  });
+
+  it('renders bands for events, tasks and routines, each tagged by kind', () => {
+    const html = render({ items: [
+      event('e', '09:00', 60), task('t', '10:00', 60),
+      ...tagKind([{ id: 'r', name: 'Lunch', startTime: '12:00', duration: 60, isAllDay: false, completed: false }], 'routine'),
+    ] });
+    expect(html).toContain('data-band="e" data-kind="event"');
+    expect(html).toContain('data-band="t" data-kind="task"');
+    expect(html).toContain('data-band="r" data-kind="routine"');
+    expect(count(html, /data-band=/g)).toBe(3);
+  });
+
+  it('separates events from tasks by more than colour: events are hatched and outlined', () => {
+    const html = render({ items: [event('e', '09:00', 60), task('t', '10:00', 60)] });
+    const eventMarkup = html.slice(html.indexOf('data-band="e"'), html.indexOf('data-band="t"'));
+    expect(eventMarkup).toMatch(/fill="url\(#mdc-hatch-/);
+    expect(eventMarkup).toContain('stroke-gray-500');
+    const taskMarkup = html.slice(html.indexOf('data-band="t"'));
+    expect(taskMarkup).not.toMatch(/fill="url\(#/);
+    expect(html).toContain('<pattern id="mdc-hatch-');
+  });
+
+  it('renders a point item as a hollow diamond, not a band', () => {
+    const html = render({ items: [task('p', '11:00', 0)] });
+    expect(html).toContain('data-point="p" data-kind="task"');
+    expect(html).not.toContain('data-band=');
+    expect(html).toMatch(/data-point="p"[^>]*d="M[\d.]+,[\d.]+ L/);
+    expect(html).toMatch(/data-point="p"[^>]*fill-white dark:fill-gray-900/);
+  });
+
+  it('renders all-day items, deadlines included, as markers in the gutter in a fixed order', () => {
+    const html = render({ items: [
+      task('t-ad', null, null, { isAllDay: true }),
+      { id: 'dl', kind: 'deadline', isAllDay: true, completed: false, date: DATE },
+      task('e-ad', null, null, { isAllDay: true, imported: true }),
+      ...tagKind([{ id: 'r-ad', name: 'Stretch', startTime: null, duration: null, isAllDay: true, completed: false }], 'routine'),
+      task('timed', '09:00', 60),
+    ] });
+    const gutterStart = html.indexOf('data-month-cell-gutter');
+    expect(gutterStart).toBeGreaterThan(-1);
+    const order = [...html.matchAll(/data-allday-marker="([^"]+)" data-kind="([^"]+)"/g)].map((m) => m[2]);
+    expect(order).toEqual(['deadline', 'event', 'task', 'routine']);
+    expect(html.indexOf('data-allday-marker="dl"')).toBeGreaterThan(gutterStart);
+    expect(html).toContain('data-band="timed"');
+    expect(html).not.toContain('data-month-cell-allday-row');
+  });
+
+  it('draws the gutter only when the gutter width is nonzero, and moves all-day marks to the header otherwise', () => {
+    const items = [task('ad', null, null, { isAllDay: true }), task('a', '09:00', 60)];
+    const withGutter = render({ items, gutterWidth: 16 });
+    expect(withGutter).toContain('data-month-cell-gutter');
+    expect(withGutter).not.toContain('data-month-cell-allday-row');
+    expect(withGutter).toContain('data-allday-marker="ad"');
+
+    const noGutter = render({ items, gutterWidth: 0 });
+    expect(noGutter).not.toContain('data-month-cell-gutter');
+    expect(noGutter).toContain('data-month-cell-allday-row');
+    expect(noGutter).toContain('data-allday-marker="ad"');
+    expect(noGutter).toContain('data-band="a"');
+  });
+
+  it('shows the overflow count when the layout hides bands past the lane cap', () => {
+    const html = render({ items: [task('a', '09:00', 60), task('b', '09:10', 50), task('c', '09:20', 40), task('d', '09:30', 30)] });
+    expect(html).toContain('data-month-cell-overflow="+1"');
+    expect(visibleText(html)).toBe('16+1');
+    expect(count(html, /data-band=/g)).toBe(3);
+  });
+
+  it('counts all-day marks that do not fit into the overflow', () => {
+    const many = Array.from({ length: 12 }, (_, i) => task(`ad${i}`, null, null, { isAllDay: true }));
+    const html = render({ items: many, width: 40, height: 40, gutterWidth: 0 });
+    expect(html).toMatch(/data-month-cell-overflow="\+\d+"/);
+    expect(count(html, /data-allday-marker=/g)).toBeLessThan(12);
+  });
+
+  it('never renders item text', () => {
+    const html = render({ items: [event('e', '09:00', 60), task('t', '10:00', 60), task('p', '11:00', 0), task('ad', null, null, { isAllDay: true })] });
+    expect(html).not.toContain('Title of');
+    expect(visibleText(html)).toBe('16');
+  });
+
+  it('marks today and dims days outside the month', () => {
+    expect(render({ items: [], isToday: true })).toContain('data-today="true"');
+    expect(render({ items: [], isToday: true })).toContain('bg-blue-600 text-white');
+    expect(render({ items: [] })).not.toContain('data-today');
+    expect(render({ items: [], inMonth: false })).toContain('opacity-40');
+    expect(render({ items: [], inMonth: false })).toContain('data-in-month="false"');
+  });
+
+  it('is one button with an accessible name, and nothing inside it is interactive', () => {
+    const html = render({ items: [task('a', '09:00', 60)], label: 'Wednesday 16 September, 1 task' });
+    expect(html).toMatch(/^<button type="button"/);
+    expect(html).toContain('aria-label="Wednesday 16 September, 1 task"');
+    expect(count(html, /<button/g)).toBe(1);
+    expect(html).not.toMatch(/<a /);
+    expect(render({ items: [] })).toContain('aria-label="2026-09-16"');
+  });
+});

--- a/src/constants/monthView.js
+++ b/src/constants/monthView.js
@@ -41,6 +41,20 @@ export const MONTH_CELL_LAYOUT = Object.freeze({
    * height) stay two marks instead of merging into one longer band.
    */
   bandGap: 1,
+
+  /**
+   * The strip above the timeline that holds the date number (and, in a cell
+   * with no gutter, the all-day markers). The timeline gets the rest of the
+   * cell's height, so the hour window maps onto cellHeight - headerHeight.
+   */
+  headerHeight: 18,
+
+  /** Point-marker half-diagonal, in px: the diamond spans twice this. */
+  pointSize: 3,
+
+  /** All-day marker edge and the gap between stacked markers, in px. */
+  gutterMarkerSize: 6,
+  gutterMarkerGap: 2,
 });
 
 export const MONTH_CELL_HOUR_WINDOW = MONTH_CELL_LAYOUT.window;
@@ -48,3 +62,4 @@ export const MONTH_CELL_MIN_BAND_HEIGHT = MONTH_CELL_LAYOUT.minBandHeight;
 export const MONTH_CELL_MAX_LANES = MONTH_CELL_LAYOUT.maxLanes;
 export const MONTH_CELL_LANE_GAP = MONTH_CELL_LAYOUT.laneGap;
 export const MONTH_CELL_BAND_GAP = MONTH_CELL_LAYOUT.bandGap;
+export const MONTH_CELL_HEADER_HEIGHT = MONTH_CELL_LAYOUT.headerHeight;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -84,11 +84,33 @@ class ErrorBoundary extends React.Component {
   }
 }
 
+// ── TEMPORARY: month view step 2 dev harness ────────────────────────────────
+// Renders components/month/MonthCellDevHarness.jsx INSTEAD of the app when
+// asked for explicitly: `?month-cells` in the URL, or localStorage
+// 'day-planner-dev-month-cells' = '1' (the only route on a device build, where
+// the URL is fixed). Lazy, so the main bundle carries only this gate. Delete
+// this block and the harness file once the month grid (step 3) renders real
+// cells.
+const monthCellsDevRequested = (() => {
+  try {
+    return new URLSearchParams(window.location.search).has('month-cells')
+      || window.localStorage.getItem('day-planner-dev-month-cells') === '1'
+  } catch {
+    return false
+  }
+})()
+const MonthCellDevHarness = monthCellsDevRequested
+  ? React.lazy(() => import('./components/month/MonthCellDevHarness.jsx'))
+  : null
+// ── end TEMPORARY ────────────────────────────────────────────────────────────
+
 function mount() {
   ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>
       <ErrorBoundary>
-        <App />
+        {MonthCellDevHarness
+          ? <React.Suspense fallback={null}><MonthCellDevHarness /></React.Suspense>
+          : <App />}
       </ErrorBoundary>
     </React.StrictMode>,
   )

--- a/src/utils/monthCellLayout.js
+++ b/src/utils/monthCellLayout.js
@@ -22,7 +22,10 @@ import { isCalendarEvent } from '@glance-apps/agenda-core';
 import { MONTH_CELL_LAYOUT } from '../constants/monthView.js';
 import { assignLanes, maxLaneCount } from './intervalLanes.js';
 
-export const DAY_CELL_KINDS = Object.freeze(['event', 'task', 'routine']);
+// 'deadline' is a caller-built all-day item (a task's deadline falling on
+// this date, tagged by the grid); it never has a time, so it can only ever
+// reach the allDay collection, where the renderer draws it as its own mark.
+export const DAY_CELL_KINDS = Object.freeze(['event', 'task', 'routine', 'deadline']);
 
 /** Stamp a kind onto items that cannot be told apart by shape (routines). */
 export const tagKind = (items, kind) => (items || []).map((item) => ({ ...item, kind }));

--- a/src/utils/monthCellLayout.test.js
+++ b/src/utils/monthCellLayout.test.js
@@ -296,6 +296,15 @@ describe('layoutDayCell — item kinds and dates', () => {
     expect(dayCellItemKind({ id: 'x', kind: 'nonsense' })).toBe('task');
   });
 
+  it('keeps a deadline-tagged all-day item as its own kind', () => {
+    const out = layoutDayCell([
+      { id: 'dl-1', kind: 'deadline', isAllDay: true, completed: false, date: DATE },
+      task('a', '09:00', 60),
+    ], DATE, W, H);
+    expect(out.allDay).toEqual([{ id: 'dl-1', kind: 'deadline', completed: false }]);
+    expect(out.bands.map((b) => b.id)).toEqual(['a']);
+  });
+
   it('tags routines as bands like any other, marked by kind', () => {
     const routines = tagKind([{ id: 'r', name: 'Lunch', startTime: '12:00', duration: 60, isAllDay: false, completed: false }], 'routine');
     const out = layoutDayCell([task('a', '12:30', 30), ...routines], DATE, W, H);


### PR DESCRIPTION
## Summary

Step 2 of the month view. Additive only: a new `MonthDayCell` component in `src/components/month/`, a temporary dev harness, and two small extensions to step 1. No existing component or view is modified and nothing routes to the cell yet.

`MonthDayCell` takes a date, its items, measured width and height, an optional gutter width, `isToday`, `inMonth`, an accessible `label`, and an `onSelect` prop (wired, unimplemented by callers until the step 4 sheet). It calls `layoutDayCell` and draws the result as SVG.

## Encoding

Nothing rests on colour alone, and there is no text beyond the date number and an overflow count.

| Collection | Drawn as |
|---|---|
| Task band | solid band, app blue |
| Event band | outlined band with a diagonal hatch, app gray |
| Routine band | same band drawn faint, app teal |
| Point (timed, zero duration) | hollow diamond at its minute, stroked in the kind's colour, so it never reads as a very short band |
| All-day, deadlines included | small marks with no vertical meaning: stacked top-down in the gutter in a fixed order (deadline flag, event, task, routine), or a row beside the date number when there is no gutter |
| Overflow | "+N" badge for bands past the lane cap plus any all-day marks that did not fit |

The gutter is its own track: inset background and a hairline. Today gets the app's blue date pill and tint; days outside the month are dimmed. Colours are Tailwind tokens with `dark:` variants, so the cell follows the root `dark` class like everything else. No hover states anywhere; the whole cell is one `<button>`. Desktop and phone share the encoding; only the gutter and the pixels-per-hour vary.

## Step 1 extensions

- `deadline` is now an accepted item kind (all-day only), so the grid can tag a task's deadline falling on a date and the cell can draw it as a flag. One layout test added.
- Header height and point/marker sizes join `MONTH_CELL_LAYOUT` as plain data.

## Temporary dev harness

`MonthCellDevHarness.jsx` renders every scenario (empty, single, three-way, past the lane cap, all-day beside timed, points, the busy-day fixture) at five fixed sizes plus a seven-column fit-to-screen row, with a dark toggle. It replaces the app only when asked for explicitly:

- web / Electron dev server: `?month-cells` in the URL
- device build: set localStorage `day-planner-dev-month-cells` to `1` and reload (chrome://inspect on a debug Android build)

The gate is a lazy import in `main.jsx`, marked TEMPORARY with the harness. Both go once step 3 renders real cells.

## Tests

`MonthDayCell.test.jsx` (static markup, like the repo's other component tests): each collection renders and is tagged by kind, events carry the hatch and outline, points are diamonds, all-day marks appear in the gutter in the fixed order, the gutter exists only with a nonzero width and marks move to the header without it, the overflow badge shows the count, no item text ever renders, today and outside-month treatments, and a single button with an accessible name. No geometry math.

Full suite 256 files / 3563 tests green, `npm run lint` clean. Rendered in Chromium at 1400px and 390px in both themes with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx)_