### PR TITLE
Month view: visual pass, real task colours, proportional cell metrics

### DIFF
--- a/src/components/month/MonthDayCell.jsx
+++ b/src/components/month/MonthDayCell.jsx
@@ -1,104 +1,121 @@
 import React from 'react';
 import { layoutDayCell } from '../../utils/monthCellLayout.js';
-import { MONTH_CELL_LAYOUT } from '../../constants/monthView.js';
+import { monthCellMetrics } from '../../utils/monthCellMetrics.js';
+import { taskColorToHex } from '../../utils/colorUtils.js';
 
-// Month view day cell (step 2). A miniature vertical timeline: the layout
-// engine (utils/monthCellLayout.js) decides where everything goes, this
-// component only draws it. There is no text in a cell beyond the date
-// number and an overflow count, no hover state on anything, and the whole
-// cell is the one tap target. Desktop and phone share the encoding; only the
-// gutter (present when gutterWidth > 0) and the pixels-per-hour vary.
+// Month view day cell (step 2, visual pass). A miniature vertical timeline:
+// the layout engine (utils/monthCellLayout.js) decides where everything
+// goes, this component only draws it. There is no text in a cell beyond the
+// date number and an overflow count, no hover state on anything, and the
+// whole cell is the one tap target. Desktop and phone share the encoding;
+// every size below is a proportion of the cell (utils/monthCellMetrics.js),
+// so a phone cell and a desktop cell are the same drawing at two scales.
 //
 // Encoding, chosen so nothing rests on colour alone:
-//   task     solid band, app blue
-//   event    solid band, app gray, with a darker cap on its left edge (the
-//            app's own left-edge convention, as on frames and hyperGLANCE
-//            bars); a cap survives the 4px minimum band height where an
-//            outline would eat the fill and a hatch reads as a dashed bar
-//   routine  solid band drawn faint, app teal
-//   point    hollow diamond at the minute, stroked in the kind's colour
-//   all-day  small marks with NO vertical meaning: stacked top-down in the
-//            gutter in a fixed order (deadline, event, task, routine), or
-//            in a row beside the date number when there is no gutter; the
-//            gutter itself is only a hairline, so an empty track stays quiet
+//   task     rounded band in a pale tint of the task's OWN colour, as in
+//            every other view
+//   event    rounded band in a pale gray tint with a darker cap on its left
+//            edge (the app's left-edge convention, as on frames and
+//            hyperGLANCE bars); the cap is what says "event", so a gray
+//            task still reads apart from an event
+//   routine  the same band, teal, fainter still
+//   point    hollow rounded diamond at the minute, stroked in the item's
+//            colour, so it never reads as a short band
+//   all-day  small rounded marks with NO vertical meaning: stacked top-down
+//            in the gutter in a fixed order (deadline, event, task, routine),
+//            or in a row beside the date number when there is no gutter;
+//            the gutter itself is only a hairline
 //   deadline a flag mark, app rose, all-day only
-// Colours are the app's Tailwind tokens with dark: variants, so the cell
-// follows the root `dark` class like everything else.
+// Bands always span the full lane width with one uniform inset from the
+// cell edges and from the gutter: horizontal position carries no meaning
+// and widths stay comparable across days. Theme handling is the app's root
+// `dark` class via Tailwind variants; tints use the item colour at a
+// theme-specific opacity.
 
 const ALL_DAY_ORDER = ['deadline', 'event', 'task', 'routine'];
 const orderAllDay = (list) => [...list].sort((a, b) =>
   ALL_DAY_ORDER.indexOf(a.kind) - ALL_DAY_ORDER.indexOf(b.kind) || Number(a.completed) - Number(b.completed));
 
-const STROKE = {
-  task: 'stroke-blue-500 dark:stroke-blue-400',
-  event: 'stroke-gray-500 dark:stroke-gray-400',
-  routine: 'stroke-teal-600 dark:stroke-teal-500',
-  deadline: 'stroke-rose-500 dark:stroke-rose-400',
-};
-const FILL = {
-  task: 'fill-blue-500 dark:fill-blue-400',
-  event: 'fill-gray-400 dark:fill-gray-500',
-  routine: 'fill-teal-600 dark:fill-teal-500',
-  deadline: 'fill-rose-500 dark:fill-rose-400',
-};
+const TINT = '[fill-opacity:0.42] dark:[fill-opacity:0.55]';
+const TINT_FAINT = '[fill-opacity:0.22] dark:[fill-opacity:0.3]';
+const EVENT_FILL = `fill-gray-400 dark:fill-gray-500 ${TINT}`;
 const EVENT_EDGE = 'fill-gray-600 dark:fill-gray-300';
-const EVENT_EDGE_W = 2;
+const EVENT_STROKE = 'stroke-gray-500 dark:stroke-gray-400';
+const ROUTINE_FILL = `fill-teal-500 ${TINT_FAINT}`;
+const ROUTINE_STROKE = 'stroke-teal-600 dark:stroke-teal-400';
+const DEADLINE_FILL = 'fill-rose-500 dark:fill-rose-400';
+const DEADLINE_STROKE = 'stroke-rose-500 dark:stroke-rose-400';
 const dim = (completed) => (completed ? 'opacity-50' : '');
 
-/** One timed band. Events get the left-edge cap, routines the faint fill. */
-function Band({ band }) {
+/** A rect with only its left corners rounded: the event cap, flush with the band's edge. */
+const leftCapPath = (x, y, w, h, radius) => {
+  const r = Math.min(radius, h / 2, w);
+  return `M${x + r},${y} H${x + w} V${y + h} H${x + r} A${r},${r} 0 0 1 ${x},${y + h - r} V${y + r} A${r},${r} 0 0 1 ${x + r},${y} Z`;
+};
+
+/** The item's own colour, as the other views draw it. */
+const itemHex = (item) => taskColorToHex(item?.color, item?.nativeCalendarColor);
+
+/** One timed band. Tasks in their own tint, events gray with the cap, routines faint teal. */
+function Band({ band, item, m }) {
   const { kind, x, y, width, height, completed } = band;
+  const r = Math.min(m.radius, height / 2, width / 2);
   const common = { 'data-band': band.id, 'data-kind': kind };
   if (kind === 'event') {
-    const cap = Math.min(EVENT_EDGE_W, width);
     return (
       <g {...common} className={dim(completed)}>
-        <rect x={x} y={y} width={width} height={height} rx={1} className={FILL.event} />
-        <rect data-event-edge="" x={x} y={y} width={cap} height={height} className={EVENT_EDGE} />
+        <rect x={x} y={y} width={width} height={height} rx={r} className={EVENT_FILL} />
+        <path data-event-edge="" d={leftCapPath(x, y, Math.min(m.capWidth, width), height, r)} className={EVENT_EDGE} />
       </g>
     );
   }
-  const faint = kind === 'routine' ? 'opacity-30' : '';
-  return (
-    <rect {...common} x={x} y={y} width={width} height={height} rx={1}
-      className={`${FILL[kind] || FILL.task} ${faint} ${dim(completed)}`} />
-  );
+  if (kind === 'routine') {
+    return <rect {...common} x={x} y={y} width={width} height={height} rx={r} className={`${ROUTINE_FILL} ${dim(completed)}`} />;
+  }
+  return <rect {...common} x={x} y={y} width={width} height={height} rx={r} fill={itemHex(item)} className={`${TINT} ${dim(completed)}`} />;
 }
 
-/** A moment with no length: a hollow diamond, so it never reads as a short band. */
-function Point({ point, x }) {
-  const s = MONTH_CELL_LAYOUT.pointSize;
+/** A moment with no length: a hollow rounded diamond, so it never reads as a short band. */
+function Point({ point, item, x, m }) {
+  const side = m.pointSize * 1.6;
   const { y, kind, completed } = point;
+  const strokeClass = kind === 'event' ? EVENT_STROKE : kind === 'routine' ? ROUTINE_STROKE : '';
   return (
-    <path data-point={point.id} data-kind={kind}
-      d={`M${x},${y - s} L${x + s},${y} L${x},${y + s} L${x - s},${y} Z`}
-      strokeWidth={1.25} className={`fill-white dark:fill-gray-900 ${STROKE[kind] || STROKE.task} ${dim(completed)}`} />
+    <rect data-point={point.id} data-kind={kind}
+      x={x - side / 2} y={y - side / 2} width={side} height={side} rx={side * 0.3}
+      transform={`rotate(45 ${x} ${y})`} strokeWidth={1.25}
+      stroke={strokeClass ? undefined : itemHex(item)}
+      className={`fill-white dark:fill-gray-900 ${strokeClass} ${dim(completed)}`} />
   );
 }
 
 /** An all-day mark. Position is the caller's; it carries no time. */
-function AllDayMark({ item, x, y }) {
-  const m = MONTH_CELL_LAYOUT.gutterMarkerSize;
-  const common = { 'data-allday-marker': item.id, 'data-kind': item.kind, className: dim(item.completed) };
-  if (item.kind === 'deadline') {
+function AllDayMark({ entry, item, x, y, size, m }) {
+  const s = size;
+  const r = Math.max(1.5, s * 0.25);
+  const common = { 'data-allday-marker': entry.id, 'data-kind': entry.kind, className: dim(entry.completed) };
+  if (entry.kind === 'deadline') {
     // A flag: pole on the left, pennant to the right.
     return (
       <g {...common}>
-        <path d={`M${x + 1},${y} v${m}`} strokeWidth={1.25} className={STROKE.deadline} />
-        <path d={`M${x + 1},${y} h${m - 1} l-2,${m / 2 - 0.5} l2,${m / 2 - 0.5} h${-(m - 1)} Z`} className={FILL.deadline} />
+        <path d={`M${x + 1},${y} v${s}`} strokeWidth={1.25} strokeLinecap="round" className={DEADLINE_STROKE} />
+        <path d={`M${x + 1},${y} h${s - 1} l-2,${s / 2 - 0.5} l2,${s / 2 - 0.5} h${-(s - 1)} Z`}
+          strokeWidth={1} strokeLinejoin="round" className={`${DEADLINE_FILL} ${DEADLINE_STROKE}`} />
       </g>
     );
   }
-  if (item.kind === 'event') {
+  if (entry.kind === 'event') {
     return (
       <g {...common}>
-        <rect x={x} y={y} width={m} height={m} rx={1} className={FILL.event} />
-        <rect data-event-edge="" x={x} y={y} width={EVENT_EDGE_W} height={m} className={EVENT_EDGE} />
+        <rect x={x} y={y} width={s} height={s} rx={r} className={EVENT_FILL} />
+        <path data-event-edge="" d={leftCapPath(x, y, Math.min(m.capWidth, s), s, r)} className={EVENT_EDGE} />
       </g>
     );
   }
-  const faint = item.kind === 'routine' ? 'opacity-40' : '';
-  return <rect {...common} x={x} y={y} width={m} height={m} rx={1} className={`${FILL[item.kind] || FILL.task} ${faint} ${dim(item.completed)}`} />;
+  if (entry.kind === 'routine') {
+    return <rect {...common} x={x} y={y} width={s} height={s} rx={r} className={`fill-teal-500 [fill-opacity:0.5] ${dim(entry.completed)}`} />;
+  }
+  return <rect {...common} x={x} y={y} width={s} height={s} rx={r} fill={itemHex(item)} className={`[fill-opacity:0.85] ${dim(entry.completed)}`} />;
 }
 
 /**
@@ -108,7 +125,8 @@ function AllDayMark({ item, x, y }) {
  *   routines tagged kind 'routine' and deadlines tagged kind 'deadline' (see tagKind)
  * @param {number} props.width         measured cell width, px
  * @param {number} props.height        measured cell height, px
- * @param {number} [props.gutterWidth=0]  right-hand all-day track; 0 on narrow cells
+ * @param {number} [props.gutterWidth] all-day track width; omit to follow the
+ *   width rule in constants (present on wide cells, absent on narrow), 0 for none
  * @param {boolean} [props.isToday=false]
  * @param {boolean} [props.inMonth=true]  false dims the cell (adjacent month)
  * @param {string} [props.label]       accessible name; defaults to the date
@@ -116,26 +134,28 @@ function AllDayMark({ item, x, y }) {
  *   day sheet it opens is step 4, so callers leave it unwired for now
  */
 export default function MonthDayCell({
-  date, items, width, height, gutterWidth = 0, isToday = false, inMonth = true, label, onSelect,
+  date, items, width, height, gutterWidth, isToday = false, inMonth = true, label, onSelect,
 }) {
-  const { headerHeight, gutterMarkerSize: m, gutterMarkerGap: g } = MONTH_CELL_LAYOUT;
-  const timelineHeight = Math.max(0, height - headerHeight);
-  const layout = layoutDayCell(items, date, width, timelineHeight, { gutterWidth });
-  const { usableWidth, bands, points, overflow } = layout;
-  const hasGutter = layout.gutterWidth > 0;
+  const m = monthCellMetrics(width, height, { gutter: gutterWidth === undefined ? 'auto' : gutterWidth });
+  const layout = layoutDayCell(items, date, m.timelineWidth, m.timelineHeight);
+  const { bands, points, overflow } = layout;
+  const byId = new Map((items || []).map((item) => [String(item?.id), item]));
   const allDay = orderAllDay(layout.allDay);
   const dayNumber = Number(String(date).slice(8, 10)) || '';
+  const { markerSize: ms, markerGap: mg } = m;
 
   // All-day marks: stacked in the gutter, or a row in the header. Whatever
   // does not fit joins the overflow count instead of being drawn smaller.
-  const gutterCapacity = hasGutter ? Math.max(0, Math.floor((timelineHeight - 2 + g) / (m + g))) : 0;
-  const headerCapacity = hasGutter ? 0 : Math.max(0, Math.floor((width - headerHeight - 6 + g) / (m + g)));
-  const capacity = hasGutter ? gutterCapacity : headerCapacity;
-  const shownAllDay = allDay.slice(0, capacity);
+  const gutterCapacity = m.hasGutter ? Math.max(0, Math.floor((m.timelineHeight + mg) / (ms + mg))) : 0;
+  const headerCapacity = m.hasGutter ? 0 : Math.max(0, Math.floor((width - m.dateSize - 2 * m.inset - 4 + mg) / (ms + mg)));
+  const shownAllDay = allDay.slice(0, m.hasGutter ? gutterCapacity : headerCapacity);
   const overflowCount = overflow.hidden.length + (allDay.length - shownAllDay.length);
   const showOverflow = overflowCount > 0 || overflow.crowded;
   const overflowText = overflowCount > 0 ? `+${overflowCount}` : '+';
-  const badgeW = 6 + 5 * overflowText.length;
+  const badgeH = Math.max(11, Math.round(m.headerHeight * 0.6));
+  const badgeFont = Math.round(badgeH * 0.72);
+  const badgeW = Math.round(badgeH * 0.5 + badgeFont * 0.62 * overflowText.length);
+  const gutterX = width - m.gutterWidth;
 
   return (
     <button
@@ -147,54 +167,55 @@ export default function MonthDayCell({
       onClick={onSelect ? () => onSelect(date) : undefined}
       className={`relative block p-0 m-0 border-0 bg-transparent text-left select-none appearance-none cursor-pointer overflow-hidden
         focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500
-        ${isToday ? 'bg-blue-50 dark:bg-blue-900/20' : ''} ${inMonth ? '' : 'opacity-40'}`}
+        ${isToday ? 'bg-blue-50/70 dark:bg-blue-900/15' : ''} ${inMonth ? '' : 'opacity-40'}`}
       style={{ width, height }}
     >
-      <div className="absolute top-0 left-0 right-0 flex items-center gap-1 px-[3px]" style={{ height: headerHeight }}>
-        <span
-          data-month-cell-date
-          className={`inline-flex items-center justify-center text-[11px] font-semibold leading-none tabular-nums shrink-0
-            ${isToday ? 'bg-blue-600 text-white rounded-full' : 'text-stone-700 dark:text-gray-200'}`}
-          style={{ width: headerHeight - 4, height: headerHeight - 4 }}
-        >
-          {dayNumber}
-        </span>
-        {!hasGutter && shownAllDay.length > 0 && (
-          <svg data-month-cell-allday-row width={shownAllDay.length * (m + g) - g} height={m} aria-hidden="true" className="shrink-0">
-            {shownAllDay.map((item, i) => <AllDayMark key={item.id} item={item} x={i * (m + g)} y={0} />)}
-          </svg>
-        )}
-      </div>
-
       <svg
         data-month-cell-timeline
         width={width}
-        height={timelineHeight}
-        viewBox={`0 0 ${width} ${timelineHeight}`}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
         aria-hidden="true"
-        className="absolute left-0 block"
-        style={{ top: headerHeight }}
+        className="absolute inset-0 block"
       >
-        {hasGutter && (
+        {m.hasGutter && (
           <g data-month-cell-gutter>
             {/* A hairline only: the track is a quiet edge, never a block of fill. */}
-            <line x1={usableWidth + 0.5} y1={0} x2={usableWidth + 0.5} y2={timelineHeight} strokeWidth={1} className="stroke-stone-300 dark:stroke-white/15" />
+            <line x1={gutterX + 0.5} y1={m.timelineTop} x2={gutterX + 0.5} y2={m.timelineTop + m.timelineHeight}
+              strokeWidth={1} strokeLinecap="round" className="stroke-stone-300 dark:stroke-white/15" />
             {shownAllDay.map((item, i) => (
-              <AllDayMark key={item.id} item={item} x={usableWidth + (layout.gutterWidth - m) / 2} y={2 + i * (m + g)} />
+              <AllDayMark key={item.id} entry={item} item={byId.get(item.id)} x={gutterX + (m.gutterWidth - ms) / 2} y={m.timelineTop + i * (ms + mg)} size={ms} m={m} />
             ))}
           </g>
         )}
 
-        {bands.map((band) => <Band key={band.id} band={band} />)}
-        {points.map((point) => <Point key={point.id} point={point} x={usableWidth - MONTH_CELL_LAYOUT.pointSize - 2} />)}
-
-        {showOverflow && (
-          <g data-month-cell-overflow={overflowText} transform={`translate(${Math.max(0, usableWidth - badgeW - 1)}, ${Math.max(0, timelineHeight - 12)})`}>
-            <rect width={badgeW} height={11} rx={3} className="fill-stone-700 dark:fill-gray-200" />
-            <text x={badgeW / 2} y={8.5} textAnchor="middle" fontSize="8" fontWeight="600" className="fill-white dark:fill-gray-900">{overflowText}</text>
-          </g>
-        )}
+        <g data-month-cell-lanes transform={`translate(${m.timelineLeft}, ${m.timelineTop})`}>
+          {bands.map((band) => <Band key={band.id} band={band} item={byId.get(band.id)} m={m} />)}
+          {points.map((point) => <Point key={point.id} point={point} item={byId.get(point.id)} x={m.timelineWidth - m.pointSize - 1} m={m} />)}
+          {showOverflow && (
+            <g data-month-cell-overflow={overflowText} transform={`translate(${Math.max(0, m.timelineWidth - badgeW)}, ${Math.max(0, m.timelineHeight - badgeH)})`}>
+              <rect width={badgeW} height={badgeH} rx={badgeH / 3} className="fill-stone-600 dark:fill-gray-300" />
+              <text x={badgeW / 2} y={badgeH * 0.74} textAnchor="middle" fontSize={badgeFont} fontWeight="600" className="fill-white dark:fill-gray-900">{overflowText}</text>
+            </g>
+          )}
+        </g>
       </svg>
+
+      <div className="absolute top-0 left-0 right-0 flex items-center gap-1" style={{ height: m.headerHeight, paddingLeft: m.inset, paddingRight: m.inset }}>
+        <span
+          data-month-cell-date
+          className={`inline-flex items-center justify-center font-semibold leading-none tabular-nums shrink-0 rounded-md
+            ${isToday ? 'bg-blue-100 text-blue-800 dark:bg-blue-400/25 dark:text-blue-100' : 'text-stone-700 dark:text-gray-200'}`}
+          style={{ width: m.dateSize, height: m.dateSize, fontSize: m.dateFont }}
+        >
+          {dayNumber}
+        </span>
+        {!m.hasGutter && shownAllDay.length > 0 && (
+          <svg data-month-cell-allday-row width={shownAllDay.length * (ms + mg) - mg} height={ms} aria-hidden="true" className="shrink-0">
+            {shownAllDay.map((item, i) => <AllDayMark key={item.id} entry={item} item={byId.get(item.id)} x={i * (ms + mg)} y={0} size={ms} m={m} />)}
+          </svg>
+        )}
+      </div>
     </button>
   );
 }

--- a/src/components/month/MonthDayCell.test.jsx
+++ b/src/components/month/MonthDayCell.test.jsx
@@ -39,24 +39,48 @@ describe('MonthDayCell', () => {
     expect(count(html, /data-band=/g)).toBe(3);
   });
 
-  it('separates events from tasks by more than colour: events carry a left-edge cap, both solid', () => {
-    const html = render({ items: [event('e', '09:00', 60), task('t', '10:00', 60)] });
+  it('separates events from tasks by more than colour: events carry a left-edge cap, tasks their own colour', () => {
+    const html = render({ items: [event('e', '09:00', 60), task('t', '10:00', 60, { color: 'bg-purple-500' })] });
     const eventMarkup = html.slice(html.indexOf('data-band="e"'), html.indexOf('data-band="t"'));
     expect(eventMarkup).toContain('data-event-edge');
     expect(eventMarkup).toContain('fill-gray-400');
-    expect(eventMarkup).not.toContain('stroke');
     const taskMarkup = html.slice(html.indexOf('data-band="t"'));
     expect(taskMarkup).not.toContain('data-event-edge');
-    expect(taskMarkup).toContain('fill-blue-500');
+    expect(taskMarkup).toContain('fill="#a855f7"');
+    expect(taskMarkup).toContain('[fill-opacity:0.42]');
     expect(html).not.toContain('<pattern');
-    expect(html).not.toMatch(/fill="url\(#/);
+  });
+
+  it('draws each task in its own colour, a gray task still told from an event by the cap', () => {
+    const html = render({ items: [
+      task('blue', '08:00', 30), task('red', '09:00', 30, { color: 'bg-red-500' }),
+      task('native', '10:00', 30, { nativeCalendarColor: '#123456' }), task('gray', '11:00', 30, { color: 'bg-gray-500' }),
+      event('ev', '12:00', 30),
+    ] });
+    const bandOf = (id) => { const i = html.indexOf(`data-band="${id}"`); return html.slice(i, html.indexOf('data-band=', i + 1) > 0 ? html.indexOf('data-band=', i + 1) : undefined); };
+    expect(bandOf('blue')).toContain('fill="#3b82f6"');
+    expect(bandOf('red')).toContain('fill="#ef4444"');
+    expect(bandOf('native')).toContain('fill="#123456"');
+    expect(bandOf('gray')).not.toContain('data-event-edge');
+    expect(bandOf('ev')).toContain('data-event-edge');
+  });
+
+  it('rounds every band, point and mark, and insets bands uniformly from the cell edges', () => {
+    const html = render({ items: [task('a', '09:00', 60), task('p', '11:00', 0), task('ad', null, null, { isAllDay: true })] });
+    expect(html).toMatch(/data-band="a"[^>]*rx="[0-9.]+"/);
+    expect(html).toMatch(/data-point="p"[^>]*rx="[0-9.]+"/);
+    expect(html).toMatch(/data-allday-marker="ad"[^>]*rx="[0-9.]+"/);
+    // The lane group is translated by the inset; a lone band starts at x=0 inside it
+    // and spans the timeline width, which is the cell minus gutter minus two insets.
+    expect(html).toMatch(/data-month-cell-lanes="true" transform="translate\(7, \d+\)"/);
+    expect(html).toMatch(/data-band="a"[^>]*x="0"[^>]*width="130"/);
   });
 
   it('renders a point item as a hollow diamond, not a band', () => {
     const html = render({ items: [task('p', '11:00', 0)] });
     expect(html).toContain('data-point="p" data-kind="task"');
     expect(html).not.toContain('data-band=');
-    expect(html).toMatch(/data-point="p"[^>]*d="M[\d.]+,[\d.]+ L/);
+    expect(html).toMatch(/data-point="p"[^>]*transform="rotate\(45 /);
     expect(html).toMatch(/data-point="p"[^>]*fill-white dark:fill-gray-900/);
   });
 
@@ -99,8 +123,18 @@ describe('MonthDayCell', () => {
   it('shows the overflow count when the layout hides bands past the lane cap', () => {
     const html = render({ items: [task('a', '09:00', 60), task('b', '09:10', 50), task('c', '09:20', 40), task('d', '09:30', 30)] });
     expect(html).toContain('data-month-cell-overflow="+1"');
-    expect(visibleText(html)).toBe('16+1');
+    expect(visibleText(html).split('').sort().join('')).toBe('+116');
     expect(count(html, /data-band=/g)).toBe(3);
+  });
+
+  it('scales the gutter and its marks with the cell', () => {
+    const items = [task('ad', null, null, { isAllDay: true })];
+    const small = render({ items, width: 96, height: 120, gutterWidth: undefined });
+    const big = render({ items, width: 200, height: 200, gutterWidth: undefined });
+    const markW = (html) => Number(html.match(/data-allday-marker="ad"[^>]*width="([\d.]+)"/)[1]);
+    expect(markW(big)).toBeGreaterThan(markW(small));
+    const gutterX = (html) => Number(html.match(/data-month-cell-gutter="true"><line x1="([\d.]+)"/)[1]);
+    expect(96 - gutterX(small)).toBeLessThan(200 - gutterX(big));
   });
 
   it('counts all-day marks that do not fit into the overflow', () => {
@@ -116,9 +150,12 @@ describe('MonthDayCell', () => {
     expect(visibleText(html)).toBe('16');
   });
 
-  it('marks today and dims days outside the month', () => {
-    expect(render({ items: [], isToday: true })).toContain('data-today="true"');
-    expect(render({ items: [], isToday: true })).toContain('bg-blue-600 text-white');
+  it('marks today with a soft rounded square and dims days outside the month', () => {
+    const today = render({ items: [], isToday: true });
+    expect(today).toContain('data-today="true"');
+    expect(today).toMatch(/data-month-cell-date[^>]*rounded-md[^>]*bg-blue-100 text-blue-800/);
+    expect(today).not.toContain('rounded-full');
+    expect(today).not.toContain('bg-blue-600');
     expect(render({ items: [] })).not.toContain('data-today');
     expect(render({ items: [], inMonth: false })).toContain('opacity-40');
     expect(render({ items: [], inMonth: false })).toContain('data-in-month="false"');

--- a/src/components/month/MonthGrid.jsx
+++ b/src/components/month/MonthGrid.jsx
@@ -120,7 +120,6 @@ export default function MonthGrid({
                     items={items}
                     width={cell.width}
                     height={cell.height}
-                    gutterWidth={cell.gutterWidth}
                     isToday={isToday}
                     inMonth={inMonth}
                     label={monthCellLabel(dateStr, items, isToday, t, language)}

--- a/src/components/month/MonthGrid.test.jsx
+++ b/src/components/month/MonthGrid.test.jsx
@@ -83,7 +83,7 @@ describe('MonthGrid', () => {
   it('sizes cells from the area and gives wide cells a gutter, narrow cells none', async () => {
     const i18n = await i18nFor('en');
     const wide = render(i18n);
-    expect(wide).toContain('grid-template-columns:repeat(7, 160px)');
+    expect(wide).toContain('grid-template-columns:repeat(7, 140px)');
     expect(count(wide, /data-month-cell-gutter/g)).toBe(35);
     const phone = render(i18n, { width: 371, height: 480 });
     expect(phone).toContain('grid-template-columns:repeat(7, 53px)');
@@ -92,8 +92,10 @@ describe('MonthGrid', () => {
   });
 
   it('caps cell width on a very wide area instead of stretching', async () => {
-    const html = render(await i18nFor('en'), { width: 2560, height: 700 });
-    expect(html).toContain('grid-template-columns:repeat(7, 175px)');
+    const tall = render(await i18nFor('en'), { width: 2560, height: 1250 });
+    expect(tall).toContain('grid-template-columns:repeat(7, 200px)');
+    const short = render(await i18nFor('en'), { width: 2560, height: 700 });
+    expect(short).toContain('grid-template-columns:repeat(7, 140px)');
   });
 
   it('gives every cell a localized accessible label and localizes the header', async () => {

--- a/src/components/month/MonthGridDevOverlay.jsx
+++ b/src/components/month/MonthGridDevOverlay.jsx
@@ -3,8 +3,10 @@
 // │ Not linked from the app or the view cycler. Reach it with `?month-grid`  │
 // │ on the web or the Electron dev server, or on a device by setting         │
 // │ localStorage 'day-planner-dev-month-grid' to '1' (chrome://inspect on a │
-// │ debug Android build) and reloading. Delete this file and the gate in     │
-// │ src/App.jsx once the grid is routed through the view cycler.             │
+// │ debug Android build) and reloading. `?month-grid=demo` opens with the    │
+// │ generated demo month instead of real data; the header button toggles.   │
+// │ Delete this file and the gate in src/App.jsx once the grid is routed     │
+// │ through the view cycler.                                                 │
 // └──────────────────────────────────────────────────────────────────────────┘
 import React, { useMemo, useState } from 'react';
 import { X } from 'lucide-react';
@@ -12,6 +14,7 @@ import { routinesForDate } from '@glance-apps/agenda-core';
 import MonthGrid from './MonthGrid.jsx';
 import { tagKind } from '../../utils/monthCellLayout.js';
 import { monthOf } from '../../utils/monthGrid.js';
+import { generateDemoMonth } from '../../utils/monthDemoData.js';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
 
@@ -38,10 +41,26 @@ export function useMonthItemsForDate() {
   }, [getTasksForDate, getDeadlineTasksForDate, routinesEnabled, todayRoutines, routinesDate, routineCompletions]);
 }
 
+const todayStr = () => { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`; };
+
+/** Demo month as an itemsForDate, shaped like the real adapter's output. */
+function useDemoItemsForDate(year, month) {
+  return useMemo(() => {
+    const { tasks, unscheduled } = generateDemoMonth(year, month, { today: todayStr() });
+    return (dateStr) => [
+      ...tasks.filter((t) => t.date === dateStr),
+      ...unscheduled.filter((u) => u.deadline === dateStr).map((u) => ({ id: `deadline-${u.id}`, kind: 'deadline', isAllDay: true, completed: false, date: dateStr })),
+    ];
+  }, [year, month]);
+}
+
 export default function MonthGridDevOverlay() {
   const { darkMode, weekStartDay, selectedDate } = useDayPlannerCtx();
-  const itemsForDate = useMonthItemsForDate();
+  const realItemsForDate = useMonthItemsForDate();
   const [shown, setShown] = useState(() => monthOf(selectedDate instanceof Date ? selectedDate : new Date()));
+  const [demo, setDemo] = useState(() => { try { return new URLSearchParams(window.location.search).get('month-grid') === 'demo'; } catch { return false; } });
+  const demoItemsForDate = useDemoItemsForDate(shown.year, shown.month);
+  const itemsForDate = demo ? demoItemsForDate : realItemsForDate;
   const [hidden, setHidden] = useState(false);
   if (hidden) return null;
   return (
@@ -50,7 +69,11 @@ export default function MonthGridDevOverlay() {
       <div className="flex items-center gap-3 px-3 py-1 text-[11px] text-stone-500 dark:text-gray-400 shrink-0">
         <span className="font-semibold">Month grid (TEMPORARY dev overlay, real data)</span>
         <span className="hidden sm:inline">tap a cell: logs the date until the day sheet exists</span>
-        <button type="button" onClick={() => setHidden(true)} aria-label="Close" className="ml-auto p-1 rounded border border-current">
+        <button type="button" onClick={() => setDemo((v) => !v)} data-month-grid-demo={demo ? 'on' : 'off'}
+          className={`ml-auto px-2 py-0.5 rounded border border-current ${demo ? 'bg-amber-200 text-amber-900 dark:bg-amber-500/30 dark:text-amber-100' : ''}`}>
+          {demo ? 'demo month' : 'real data'}
+        </button>
+        <button type="button" onClick={() => setHidden(true)} aria-label="Close" className="p-1 rounded border border-current">
           <X size={14} />
         </button>
       </div>

--- a/src/constants/monthView.js
+++ b/src/constants/monthView.js
@@ -43,37 +43,36 @@ export const MONTH_CELL_LAYOUT = Object.freeze({
   bandGap: 1,
 
   /**
-   * The strip above the timeline that holds the date number (and, in a cell
-   * with no gutter, the all-day markers). The timeline gets the rest of the
-   * cell's height, so the hour window maps onto cellHeight - headerHeight.
+   * Cell proportions. Everything the renderer draws scales with the cell it
+   * is in (a 53px phone cell and a 200px desktop cell must both read), so
+   * each rule is a share of the cell's width or height, clamped to a
+   * pixel range. utils/monthCellMetrics.js resolves them for a given size.
+   *
+   *   maxAspect      cells never grow wider than they are tall: the timeline
+   *                  encoding assumes a portrait cell, so on a wide display
+   *                  the grid stops stretching and centres instead
+   *   maxWidth       and never past this, since a 200px cell already gives
+   *                  three lanes ~55px each and extra width adds nothing
+   *   minHeight      rows never shrink below this; a six-row month on a
+   *                  short viewport scrolls instead
+   *   gutterMinWidth the cell width at which the all-day gutter appears
+   *                  (below it the marks sit beside the date number)
    */
-  headerHeight: 18,
-
-  /** Point-marker half-diagonal, in px: the diamond spans twice this. */
-  pointSize: 3,
-
-  /** All-day marker edge and the gap between stacked markers, in px. */
-  gutterMarkerSize: 6,
-  gutterMarkerGap: 2,
-
-  /**
-   * Grid rules. A cell gets the all-day gutter once it is at least
-   * gutterMinCellWidth wide: with the 14px gutter that leaves 82px of usable
-   * width, so three lanes are still ~26px each. A 390px phone gives 53px
-   * cells (no gutter); a 768px tablet gives ~106px (gutter).
-   */
-  gutterWidth: 14,
-  gutterMinCellWidth: 96,
-
-  /**
-   * The timeline encoding assumes cells taller than they are wide, so on a
-   * wide display cells stop stretching at maxCellAspect × their height and
-   * the grid centres, leaving the spare width free (the day sheet can dock
-   * there on desktop). Rows never shrink below minCellHeight; a six-row
-   * month on a short viewport scrolls instead.
-   */
-  maxCellAspect: 1.25,
-  minCellHeight: 64,
+  cell: Object.freeze({
+    maxAspect: 1.0,
+    maxWidth: 200,
+    minHeight: 64,
+    gutterMinWidth: 96,
+    header:       Object.freeze({ of: 'height', ratio: 0.14, min: 18, max: 26 }),
+    inset:        Object.freeze({ of: 'width', ratio: 0.045, min: 3, max: 8 }),
+    padY:         Object.freeze({ of: 'height', ratio: 0.02, min: 2, max: 5 }),
+    gutter:       Object.freeze({ of: 'width', ratio: 0.13, min: 12, max: 26 }),
+    marker:       Object.freeze({ of: 'gutter', ratio: 0.55, min: 6, max: 13 }),
+    headerMarker: Object.freeze({ of: 'header', ratio: 0.4, min: 6, max: 10 }),
+    point:        Object.freeze({ of: 'width', ratio: 0.03, min: 3, max: 5 }),
+    radius:       Object.freeze({ of: 'width', ratio: 0.015, min: 2, max: 3.5 }),
+    cap:          Object.freeze({ of: 'width', ratio: 0.018, min: 2, max: 3.5 }),
+  }),
 });
 
 export const MONTH_CELL_HOUR_WINDOW = MONTH_CELL_LAYOUT.window;
@@ -81,4 +80,3 @@ export const MONTH_CELL_MIN_BAND_HEIGHT = MONTH_CELL_LAYOUT.minBandHeight;
 export const MONTH_CELL_MAX_LANES = MONTH_CELL_LAYOUT.maxLanes;
 export const MONTH_CELL_LANE_GAP = MONTH_CELL_LAYOUT.laneGap;
 export const MONTH_CELL_BAND_GAP = MONTH_CELL_LAYOUT.bandGap;
-export const MONTH_CELL_HEADER_HEIGHT = MONTH_CELL_LAYOUT.headerHeight;

--- a/src/utils/monthCellMetrics.js
+++ b/src/utils/monthCellMetrics.js
@@ -1,0 +1,42 @@
+// Resolves the month cell's proportional rules (constants/monthView.js) for
+// one cell size. Pure; the cell and the grid both read it so they agree on
+// where the gutter is and how big the marks are.
+
+import { MONTH_CELL_LAYOUT } from '../constants/monthView.js';
+
+const clamp = (v, min, max) => Math.min(max, Math.max(min, v));
+const scale = (rule, base) => clamp(Math.round(base * rule.ratio), rule.min, rule.max);
+
+/**
+ * @param {number} width   cell width, px
+ * @param {number} height  cell height, px
+ * @param {{ gutter?: 'auto' | number }} [opts]  'auto' follows the width rule;
+ *   a number forces that gutter width (0 for none)
+ */
+export function monthCellMetrics(width, height, { gutter = 'auto' } = {}) {
+  const C = MONTH_CELL_LAYOUT.cell;
+  const headerHeight = scale(C.header, height);
+  const inset = scale(C.inset, width);
+  const padY = scale(C.padY, height);
+  const gutterWidth = gutter === 'auto' ? (width >= C.gutterMinWidth ? scale(C.gutter, width) : 0) : Math.max(0, gutter);
+  const hasGutter = gutterWidth > 0;
+  const markerSize = hasGutter ? scale(C.marker, gutterWidth) : scale(C.headerMarker, headerHeight);
+  return {
+    headerHeight,
+    dateSize: headerHeight - 2,
+    dateFont: clamp(Math.round(headerHeight * 0.6), 11, 15),
+    inset,
+    padY,
+    gutterWidth,
+    hasGutter,
+    markerSize,
+    markerGap: Math.max(2, Math.round(markerSize / 3)),
+    pointSize: scale(C.point, width),
+    radius: clamp(width * C.radius.ratio, C.radius.min, C.radius.max),
+    capWidth: clamp(width * C.cap.ratio, C.cap.min, C.cap.max),
+    timelineTop: headerHeight + padY,
+    timelineHeight: Math.max(0, height - headerHeight - 2 * padY),
+    timelineLeft: inset,
+    timelineWidth: Math.max(0, width - gutterWidth - 2 * inset),
+  };
+}

--- a/src/utils/monthCellMetrics.test.js
+++ b/src/utils/monthCellMetrics.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { monthCellMetrics } from './monthCellMetrics.js';
+import { MONTH_CELL_LAYOUT } from '../constants/monthView.js';
+
+const C = MONTH_CELL_LAYOUT.cell;
+
+describe('monthCellMetrics', () => {
+  it('scales the gutter and its marks with the cell instead of fixing them', () => {
+    const small = monthCellMetrics(96, 120);
+    const big = monthCellMetrics(200, 200);
+    expect(small.gutterWidth).toBe(12);
+    expect(big.gutterWidth).toBe(26);
+    expect(big.markerSize).toBeGreaterThan(small.markerSize);
+    expect(big.inset).toBeGreaterThan(small.inset);
+    expect(big.headerHeight).toBeGreaterThan(small.headerHeight);
+  });
+
+  it('drops the gutter below the width threshold and puts the marks in the header instead', () => {
+    const phone = monthCellMetrics(53, 96);
+    expect(phone.gutterWidth).toBe(0);
+    expect(phone.hasGutter).toBe(false);
+    expect(phone.markerSize).toBeGreaterThanOrEqual(C.headerMarker.min);
+    expect(monthCellMetrics(C.gutterMinWidth, 120).hasGutter).toBe(true);
+    expect(monthCellMetrics(C.gutterMinWidth - 1, 120).hasGutter).toBe(false);
+  });
+
+  it('honours an explicit gutter override', () => {
+    expect(monthCellMetrics(160, 140, { gutter: 0 }).gutterWidth).toBe(0);
+    expect(monthCellMetrics(60, 100, { gutter: 12 }).gutterWidth).toBe(12);
+  });
+
+  it('keeps every value inside its clamp', () => {
+    for (const [w, h] of [[30, 40], [53, 96], [96, 120], [160, 140], [200, 200], [400, 400]]) {
+      const m = monthCellMetrics(w, h);
+      expect(m.headerHeight).toBeGreaterThanOrEqual(C.header.min);
+      expect(m.headerHeight).toBeLessThanOrEqual(C.header.max);
+      expect(m.inset).toBeGreaterThanOrEqual(C.inset.min);
+      expect(m.inset).toBeLessThanOrEqual(C.inset.max);
+      expect(m.pointSize).toBeGreaterThanOrEqual(C.point.min);
+      expect(m.radius).toBeLessThanOrEqual(C.radius.max);
+      expect(m.timelineWidth + m.gutterWidth + 2 * m.inset).toBe(w);
+      expect(m.timelineTop + m.timelineHeight + m.padY).toBe(h);
+    }
+  });
+});

--- a/src/utils/monthDemoData.js
+++ b/src/utils/monthDemoData.js
@@ -1,0 +1,102 @@
+// A realistic month of demo data for judging the month view against, since
+// a real calendar is rarely busy enough on cue. Deterministic per month (the
+// seed is the month), shaped exactly like the app's own tasks and inbox
+// items so it flows through the same adapters as real data. Dev use only:
+// nothing here is ever written to storage.
+//
+// Shape of the month: several events most weekdays with a mix of durations
+// and some genuine overlaps; a few tasks a day in varied colours; the odd
+// all-day item; a handful of deadlines; occasional weekend items; and a
+// couple of quiet stretches so sparse and busy days sit side by side.
+
+import { TASK_COLORS } from './colorUtils.js';
+import { daysInMonth } from './monthGrid.js';
+
+const mulberry32 = (seed) => () => {
+  seed = (seed + 0x6D2B79F5) | 0;
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+const EVENTS = ['Standup', 'Team sync', '1:1', 'Design review', 'Planning', 'Retro', 'Customer call', 'Dentist', 'Lunch with Sam', 'Board prep', 'Interview', 'Workshop', 'All hands', 'Coffee chat', 'Vendor demo'];
+const TASKS = ['Write spec', 'Review PR', 'Deep work', 'Expense report', 'Draft proposal', 'Fix login bug', 'Prep slides', 'Groceries', 'Call bank', 'Read paper', 'Plan sprint', 'Update docs', 'Gym', 'Pay rent', 'Book flights'];
+const ALL_DAY = ['Team offsite', 'Public holiday', 'Conference', "Mom's birthday", 'Out of office'];
+const DEADLINES = ['Tax filing', 'Grant application', 'Quarterly report', 'Visa renewal', 'Insurance renewal', 'Abstract submission', 'Performance review'];
+const CALENDARS = ['Work', 'Personal'];
+
+const hhmm = (min) => `${String(Math.floor(min / 60)).padStart(2, '0')}:${String(min % 60).padStart(2, '0')}`;
+const pick = (rnd, list) => list[Math.floor(rnd() * list.length)];
+const chance = (rnd, p) => rnd() < p;
+const dateStr = (y, m, d) => `${y}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+
+/**
+ * @param {number} year
+ * @param {number} month  1..12
+ * @param {{ today?: string, seed?: number }} [opts]  today: YYYY-MM-DD, so
+ *   earlier days get some completed work; seed: override the month seed
+ * @returns {{ tasks: object[], unscheduled: object[] }}  the app's own shapes
+ */
+export function generateDemoMonth(year, month, { today, seed } = {}) {
+  const rnd = mulberry32(seed ?? year * 100 + month);
+  const days = daysInMonth(year, month);
+  const stamp = new Date(year, month - 1, 1).toISOString();
+  const tasks = [];
+  const unscheduled = [];
+  let n = 0;
+  const id = (prefix) => `demo-${prefix}-${year}${String(month).padStart(2, '0')}-${++n}`;
+
+  // Two quiet stretches of three weekdays each.
+  const quiet = new Set();
+  for (let k = 0; k < 2; k++) {
+    const start = 3 + Math.floor(rnd() * (days - 8));
+    for (let d = start; d < start + 3; d++) quiet.add(d);
+  }
+
+  for (let d = 1; d <= days; d++) {
+    const ds = dateStr(year, month, d);
+    const dow = new Date(year, month - 1, d).getDay();
+    const weekend = dow === 0 || dow === 6;
+    const past = today ? ds < today : false;
+    if (quiet.has(d) && !weekend) continue;
+    if (weekend && !chance(rnd, 0.3)) continue;
+
+    const eventCount = weekend ? 1 : 1 + Math.floor(rnd() * 4);          // 1..4 on weekdays
+    const taskCount = weekend ? Math.floor(rnd() * 2) : Math.floor(rnd() * 3); // 0..2
+    const used = [];
+    const slot = () => {
+      const start = weekend ? 600 + 15 * Math.floor(rnd() * 24) : 480 + 15 * Math.floor(rnd() * 38); // 08:00..17:15
+      return start;
+    };
+    for (let i = 0; i < eventCount; i++) {
+      const duration = pick(rnd, [30, 30, 45, 60, 60, 90, 120]);
+      // About a third of the time, overlap the previous event on purpose.
+      const start = used.length && chance(rnd, 0.35) ? used[used.length - 1] + 15 : slot();
+      used.push(start);
+      tasks.push({
+        id: id('ev'), title: pick(rnd, EVENTS), date: ds, startTime: hhmm(start), duration,
+        imported: true, calendarName: pick(rnd, CALENDARS), completed: false, createdAt: stamp,
+      });
+    }
+    for (let i = 0; i < taskCount; i++) {
+      const duration = pick(rnd, [15, 30, 30, 45, 60, 90]);
+      tasks.push({
+        id: id('t'), title: pick(rnd, TASKS), date: ds, startTime: hhmm(slot()), duration,
+        color: pick(rnd, TASK_COLORS).class, completed: past && chance(rnd, 0.7), createdAt: stamp,
+      });
+    }
+    if (chance(rnd, 0.08)) {
+      const imported = chance(rnd, 0.5);
+      tasks.push({ id: id('ad'), title: pick(rnd, ALL_DAY), date: ds, isAllDay: true, startTime: '00:00', duration: 0, imported, ...(imported ? { calendarName: pick(rnd, CALENDARS) } : { color: pick(rnd, TASK_COLORS).class }), completed: false, createdAt: stamp });
+    }
+  }
+
+  // Five to seven deadlines, as inbox tasks due on a day of the month.
+  const deadlineCount = 5 + Math.floor(rnd() * 3);
+  for (let i = 0; i < deadlineCount; i++) {
+    const d = 1 + Math.floor(rnd() * days);
+    unscheduled.push({ id: id('dl'), title: pick(rnd, DEADLINES), deadline: dateStr(year, month, d), color: pick(rnd, TASK_COLORS).class, completed: false, createdAt: stamp });
+  }
+
+  return { tasks, unscheduled };
+}

--- a/src/utils/monthDemoData.test.js
+++ b/src/utils/monthDemoData.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { generateDemoMonth } from './monthDemoData.js';
+import { TASK_COLORS } from './colorUtils.js';
+
+describe('generateDemoMonth', () => {
+  const sept = generateDemoMonth(2026, 9, { today: '2026-09-12' });
+
+  it('is deterministic for a month', () => {
+    expect(generateDemoMonth(2026, 9, { today: '2026-09-12' })).toEqual(sept);
+    expect(generateDemoMonth(2026, 10)).not.toEqual(sept);
+  });
+
+  it('produces app-shaped tasks and inbox items only in that month', () => {
+    for (const t of sept.tasks) {
+      expect(t.date).toMatch(/^2026-09-\d\d$/);
+      expect(typeof t.id).toBe('string');
+      if (!t.isAllDay) {
+        expect(t.startTime).toMatch(/^\d\d:\d\d$/);
+        expect(t.duration).toBeGreaterThan(0);
+      }
+      if (!t.imported) expect(TASK_COLORS.some((c) => c.class === t.color)).toBe(true);
+    }
+    for (const u of sept.unscheduled) {
+      expect(u.deadline).toMatch(/^2026-09-\d\d$/);
+      expect(u.date).toBeUndefined();
+    }
+    expect(new Set(sept.tasks.map((t) => t.id)).size).toBe(sept.tasks.length);
+  });
+
+  it('is realistically busy: events most weekdays, some overlaps, a few all-day items and deadlines, quiet stretches', () => {
+    const byDate = new Map();
+    for (const t of sept.tasks) byDate.set(t.date, [...(byDate.get(t.date) || []), t]);
+    const weekdays = [];
+    for (let d = 1; d <= 30; d++) {
+      const dow = new Date(2026, 8, d).getDay();
+      if (dow > 0 && dow < 6) weekdays.push(`2026-09-${String(d).padStart(2, '0')}`);
+    }
+    const busyWeekdays = weekdays.filter((d) => (byDate.get(d) || []).some((t) => t.imported && !t.isAllDay));
+    expect(busyWeekdays.length).toBeGreaterThanOrEqual(weekdays.length * 0.6);
+    expect(weekdays.filter((d) => !byDate.has(d)).length).toBeGreaterThanOrEqual(3);
+    const overlaps = [...byDate.values()].filter((list) => {
+      const timed = list.filter((t) => !t.isAllDay).map((t) => { const [h, m] = t.startTime.split(':').map(Number); const s = h * 60 + m; return [s, s + t.duration]; });
+      return timed.some((a, i) => timed.some((b, j) => i !== j && a[0] < b[1] && b[0] < a[1]));
+    });
+    expect(overlaps.length).toBeGreaterThanOrEqual(4);
+    expect(sept.tasks.filter((t) => t.isAllDay).length).toBeGreaterThanOrEqual(1);
+    expect(sept.unscheduled.length).toBeGreaterThanOrEqual(5);
+    expect(new Set(sept.tasks.filter((t) => t.color).map((t) => t.color)).size).toBeGreaterThanOrEqual(4);
+    expect(sept.tasks.some((t) => t.completed)).toBe(true);
+    expect(sept.tasks.filter((t) => t.date >= '2026-09-12' && t.completed)).toHaveLength(0);
+  });
+});

--- a/src/utils/monthGrid.js
+++ b/src/utils/monthGrid.js
@@ -55,11 +55,13 @@ export function monthGridDates(year, month, weekStartDay = 0) {
 
 /**
  * Cell size for a measured grid area: seven columns across the width, the
- * month's rows down the height, with the wide-display cap and the minimum
- * row height from the constants applied.
+ * month's rows down the height. Cells never grow wider than they are tall
+ * nor past the absolute cap (the timeline encoding assumes a portrait cell,
+ * so on a wide display the grid stops stretching and centres), and rows
+ * never shrink below the minimum height (the area scrolls instead).
  */
-export function monthCellSize(areaWidth, areaHeight, rows, { maxCellAspect, minCellHeight, gutterWidth, gutterMinCellWidth }) {
-  const height = Math.max(minCellHeight, Math.floor(areaHeight / Math.max(1, rows)));
-  const width = Math.max(1, Math.min(Math.floor(areaWidth / 7), Math.floor(height * maxCellAspect)));
-  return { width, height, gutterWidth: width >= gutterMinCellWidth ? gutterWidth : 0, scrolls: height * rows > areaHeight };
+export function monthCellSize(areaWidth, areaHeight, rows, { cell }) {
+  const height = Math.max(cell.minHeight, Math.floor(areaHeight / Math.max(1, rows)));
+  const width = Math.max(1, Math.min(Math.floor(areaWidth / 7), Math.floor(height * cell.maxAspect), cell.maxWidth));
+  return { width, height, scrolls: height * rows > areaHeight };
 }

--- a/src/utils/monthGrid.test.js
+++ b/src/utils/monthGrid.test.js
@@ -115,18 +115,19 @@ describe('monthGridDates', () => {
 
 describe('monthCellSize', () => {
   const C = MONTH_CELL_LAYOUT;
-  it('divides the area into seven columns and the month rows, with a gutter once wide enough', () => {
-    expect(monthCellSize(1120, 700, 5, C)).toEqual({ width: 160, height: 140, gutterWidth: C.gutterWidth, scrolls: false });
-    expect(monthCellSize(371, 480, 5, C)).toEqual({ width: 53, height: 96, gutterWidth: 0, scrolls: false });
+  it('divides the area into seven columns and the month rows, never wider than tall', () => {
+    expect(monthCellSize(1120, 700, 5, C)).toEqual({ width: 140, height: 140, scrolls: false });
+    expect(monthCellSize(371, 480, 5, C)).toEqual({ width: 53, height: 96, scrolls: false });
   });
   it('caps cell width on a wide display instead of stretching', () => {
-    const s = monthCellSize(2560, 700, 5, C);
-    expect(s.height).toBe(140);
-    expect(s.width).toBe(Math.floor(140 * C.maxCellAspect));
+    // 2560px wide, 250px rows: the old 1.25 aspect allowed 312px; now the
+    // absolute cap wins and the grid centres at 7 × 200.
+    expect(monthCellSize(2560, 1250, 5, C)).toEqual({ width: C.cell.maxWidth, height: 250, scrolls: false });
+    expect(monthCellSize(2560, 700, 5, C).width).toBe(140);
   });
   it('keeps six-row months usable by holding a minimum height and scrolling', () => {
     const s = monthCellSize(1120, 300, 6, C);
-    expect(s.height).toBe(C.minCellHeight);
+    expect(s.height).toBe(C.cell.minHeight);
     expect(s.scrolls).toBe(true);
     expect(monthCellSize(1120, 900, 6, C).scrolls).toBe(false);
   });


### PR DESCRIPTION
## Summary

Four fixes to the month grid and cell plus the treatment from the design mockups. No layout geometry changes; `layoutDayCell` is untouched.

## Fixes

**1. Ultrawide stretch.** Cells now stop at the smaller of their own height (never wider than tall) and an absolute 200px, then the grid centres. A 2560px monitor with 250px rows gets 200×250 cells instead of 285×250. Rationale: a 200px cell already gives three lanes about 55px each; wider bands add nothing while the timeline is the informative axis, and the spare width stays free for the step 4 sheet to dock on desktop.

**2. Real task colours.** Each task band is a pale tint of the task's own colour via `taskColorToHex`, the same call every other view uses. Events keep the gray tint with the darker left-edge cap. Where a task's colour is near the event gray (the palette has no gray, but a native calendar colour could be), the cap alone still separates them, since only events carry it.

**3. Gutters scale.** Header height, inset, gutter width, mark size, point size, corner radius and cap width are shares of the cell size clamped to ranges, resolved by a new `monthCellMetrics` module. A 96px cell gets a 12px gutter with 7px marks; a 200px cell gets 26px and 13px. The cell now decides its own gutter from its width, so `gutterWidth` is an optional override.

**4. Today marker.** A soft rounded square (blue-100 on blue-800 in light, muted blue in dark) sized with the header, replacing the bright circle.

## Treatment

Rounded corners on every band, point and gutter mark. One uniform horizontal inset from the cell edges and the same padding before the gutter hairline, so widths stay comparable across days. Pale tints in place of saturated fills, at a theme-specific opacity. Vertical breathing room so bands never touch the date number or the borders. Bands still span their full lane width; horizontal position carries no meaning.

## Test data

`monthDemoData.js` generates a realistic, deterministic month in the app's own task and inbox shapes: one to four events most weekdays with a mix of durations and deliberate overlaps, up to two tasks a day in varied colours, occasional all-day items, five to seven deadlines, some weekend items, two quiet stretches, and completed work on past days. The dev overlay toggles it with a header button, and `?month-grid=demo` opens with it. Nothing is written to storage.

## Verification

New tests for the metrics rules and the generator; cell and grid tests updated for the tints, rounding, uniform inset, scaled gutter, today marker and new caps. Full suite 260 files / 3595 tests green, `npm run lint` clean. Rendered in Chromium at 1400px, 390px and 2560px in both themes on the demo month and a sparse seeded month, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx)_