### PR TITLE
CLAUDE.md: document the Todoist integration's load-bearing rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,34 @@ consumes the observation stream, add or extend a scenario in
 `scope.scenarios.test.ts` rather than relying on a manual vault test. Obsidian
 Sync timing, real editor buffers, and Templater stay manual.
 
+# Todoist integration
+
+`src/todoist/` is a read-source integration: Todoist supplies tasks, dayGLANCE
+owns the time blocks. `core.js` is pure and holds every data-safety rule;
+`client.js` owns the transport and the `dg-todoist-*` storage keys;
+`useTodoistSync.js` wires them to React state. `docs/todoist-integration.md`
+describes the user-facing behaviour.
+
+Rules that are load-bearing rather than stylistic, each covered by tests:
+
+- **A missing source record means no information, never deletion.** Todoist
+  snapshots list active resources, so absence is not evidence a task was
+  completed or deleted. See the guards in `reconcileTask` and `pruneCache`.
+- **Empty filters import nothing.** `matches` fails closed rather than treating
+  "no criteria" as "everything".
+- **The hook receives `recycleBin` but not `setRecycleBin`.** The integration is
+  structurally unable to remove a user's tasks. Keep it that way.
+- **Writeback is guarded and one-way.** Only ordinary non-recurring leaf tasks
+  are closed, with durable command UUIDs written before the request so a retry
+  cannot double-close. Nothing else is ever sent to Todoist.
+- **The cache is pruned before every persist.** It shares a ~5 MiB localStorage
+  budget with everything else, so inactive records that nothing references are
+  dropped (`pruneCache`).
+
+Strings live in the normal locale bundles under the `todoist` prefix, not in a
+feature-local namespace. Add new keys to `public/locales/*/translation.json`;
+`locales.test.js` enforces coverage across every language.
+
 # App.jsx — Ongoing Decomposition
 
 `App.jsx` started at ~30,000 lines and has been reduced to ~9,600 across four refactor passes. All previously listed extraction candidates are done:


### PR DESCRIPTION
Post-merge follow-up to #1604.

`src/todoist/` arrived as a third sync surface with no entry in `CLAUDE.md`. The file already documents the Obsidian bridge harness and the `App.jsx` extraction pattern, so this adds the equivalent for Todoist.

## What it covers

A short map of the layer split (`core.js` pure and holding the data-safety rules, `client.js` owning transport and the `dg-todoist-*` keys, `useTodoistSync.js` wiring them to React state), then the invariants that are **load-bearing rather than stylistic**:

- A missing source record means no information, never deletion
- Empty filters import nothing, failing closed
- The hook receives `recycleBin` but not `setRecycleBin`, so it is structurally unable to remove a user's tasks
- Writeback is guarded and one-way
- The cache is pruned before every persist, because it shares the ~5 MiB localStorage budget

These are the ones a future change could quietly break while leaving tests that look green, which is why they are worth writing down rather than leaving in commit archaeology.

It also records that strings belong in the normal locale bundles under the `todoist` prefix, so the next person adding a key does not reintroduce a feature-local namespace. That pairs with #1624.

Documentation only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8k44pwgABpWA4bzd7RPm5

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8k44pwgABpWA4bzd7RPm5)_