### PR TITLE
Fix #tag autocomplete for non-Latin and nested tags

### DIFF
--- a/src/utils/suggestionParser.js
+++ b/src/utils/suggestionParser.js
@@ -2,6 +2,7 @@ import {
   defaultUse24HourClock,
   formatLocalizedDate,
 } from './localeFormatting.js';
+import { TAG_BODY_CHAR, TAG_NAME } from './taskUtils.js';
 
 // Suggestion parser — pure functions for parsing time/tag/date/priority/duration
 // shorthand syntax from task input text.  No React state dependencies.
@@ -16,12 +17,16 @@ export const getPartialTag = (text, cursorPos) => {
     const char = text[startIndex];
     if (char === '#') {
       const partial = text.slice(startIndex + 1, cursorPos);
-      if (partial === '' || /^[a-zA-Z]\w*$/.test(partial)) {
+      if (partial === '' || TAG_NAME.test(partial)) {
         return { tag: partial.toLowerCase(), startIndex };
       }
       return null;
     }
-    if (!/\w/.test(char)) return null;
+    // Both tests come from taskUtils' tag alphabet. They used to be ASCII-only
+    // (`\w`, `[a-zA-Z]`), which stopped this scan at the first non-Latin
+    // character — and at the `/` of a nested tag — before it ever reached the
+    // `#`, so those tags could never be completed.
+    if (!TAG_BODY_CHAR.test(char)) return null;
     startIndex--;
   }
   return null;

--- a/src/utils/tagAutocomplete.test.js
+++ b/src/utils/tagAutocomplete.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { extractTags, TAG_BODY_CHAR, TAG_NAME } from './taskUtils.js';
+import { getPartialTag, getFilteredTags } from './suggestionParser.js';
+
+// Regression cover for #1614. extractTags was Unicode-aware (`\p{L}` with the
+// `u` flag) while getPartialTag was ASCII-only, so a non-Latin tag stored and
+// filtered correctly but its autocomplete never appeared: the only way to reuse
+// an existing tag was to retype it in full. The same mismatch also broke
+// completion of nested tags, because `/` is not a `\w` character.
+//
+// Both now build on the one tag alphabet exported from taskUtils, so the two
+// halves cannot drift apart again.
+
+const at = (text) => getPartialTag(text, text.length);
+
+describe('tag alphabet is shared by extraction and completion', () => {
+  it.each([
+    ['工作', 'CJK'],
+    ['café', 'accented Latin'],
+    ['Привет', 'Cyrillic'],
+    ['πλάνο', 'Greek'],
+    ['work', 'ASCII'],
+    ['work/deep', 'nested'],
+    ['to-do', 'hyphenated'],
+    ['home_2', 'digits and underscore'],
+  ])('accepts %s (%s) for both extraction and completion', (tag) => {
+    expect(extractTags(`note #${tag}`)).toEqual([tag.toLowerCase()]);
+    expect(TAG_NAME.test(tag)).toBe(true);
+    expect(at(`note #${tag}`)).toEqual({ tag: tag.toLowerCase(), startIndex: 5 });
+  });
+
+  it.each(['1bad', '-bad', '/bad'])('rejects %s from both, tags must start with a letter', (tag) => {
+    expect(extractTags(`note #${tag}`)).toEqual([]);
+    expect(TAG_NAME.test(tag)).toBe(false);
+    expect(at(`note #${tag}`)).toBeNull();
+  });
+});
+
+describe('getPartialTag', () => {
+  it('completes a partially typed non-Latin tag', () => {
+    expect(at('报告 #工')).toEqual({ tag: '工', startIndex: 3 });
+    expect(at('note #ca')).toEqual({ tag: 'ca', startIndex: 5 });
+  });
+
+  it('completes a partially typed nested tag past the slash', () => {
+    expect(at('a #work/de')).toEqual({ tag: 'work/de', startIndex: 2 });
+  });
+
+  it('returns an empty partial immediately after the hash', () => {
+    expect(at('note #')).toEqual({ tag: '', startIndex: 5 });
+  });
+
+  it('stops at characters that cannot appear in a tag', () => {
+    expect(TAG_BODY_CHAR.test(' ')).toBe(false);
+    expect(at('no hash here')).toBeNull();
+    expect(at('#done then more words')).toBeNull();
+  });
+
+  it('does not cross an earlier sigil to find a hash', () => {
+    expect(at('#tag ~15:00')).toBeNull();
+  });
+});
+
+describe('getFilteredTags', () => {
+  it('filters non-Latin tags by prefix so the dropdown can offer them', () => {
+    const all = ['工作', '工具', 'work', 'café'];
+    expect(getFilteredTags('工', all)).toEqual(['工作', '工具']);
+    expect(getFilteredTags('caf', all)).toEqual(['café']);
+    expect(getFilteredTags('', all)).toEqual([...all].sort());
+  });
+});

--- a/src/utils/taskUtils.js
+++ b/src/utils/taskUtils.js
@@ -40,12 +40,31 @@ export const completionTimestamp = (d = new Date()) => {
     `${sign}${pad(Math.floor(abs / 60))}:${pad(abs % 60)}`;
 };
 
+// The tag alphabet, defined once. Obsidian's full set — a letter, then letters,
+// digits, underscore, hyphen, and `/` for nested tags — so `#work/deep` filters
+// as `work/deep` rather than truncating to `work`.
+//
+// `\p{L}` with the `u` flag means any script, not just ASCII: `#工作` and
+// `#café` are tags as much as `#work` is.
+//
+// EXPORTED because suggestionParser.js builds the `#` autocomplete from the
+// same source. extractTags decides what IS a tag; getPartialTag decides what
+// can be COMPLETED. When those two disagreed, non-Latin tags stored and
+// filtered correctly but their autocomplete never appeared, so an existing tag
+// could only be retyped from memory.
+const TAG_START = '\\p{L}';
+const TAG_BODY = '[\\p{L}\\p{N}_/-]';
+
+/** One character that may follow the first in a tag name. */
+export const TAG_BODY_CHAR = new RegExp(`^${TAG_BODY}$`, 'u');
+/** A whole tag name, without the leading `#`. */
+export const TAG_NAME = new RegExp(`^${TAG_START}${TAG_BODY}*$`, 'u');
+// Safe to hoist despite the `g` flag: String#match resets lastIndex itself.
+const TAG_IN_TEXT = new RegExp(`#(${TAG_START}${TAG_BODY}*)`, 'gu');
+
 // Extract #hashtags from a task title (tags must start with a letter).
-// Accepts Obsidian's full tag alphabet — letters, digits, underscore, hyphen,
-// and `/` for nested tags — so `#work/deep` filters as `work/deep` rather
-// than truncating to `work` (the old regex stopped at `/` and `-`).
 export const extractTags = (title) => {
-  const matches = title.match(/#(\p{L}[\p{L}\p{N}_/-]*)/gu);
+  const matches = title.match(TAG_IN_TEXT);
   return matches ? matches.map(tag => tag.slice(1).toLowerCase()) : [];
 };
 


### PR DESCRIPTION
Fixes #1614.

## The mismatch

`extractTags` has been Unicode-aware since the Phase 4 tag work (`\p{L}` with the `u` flag), but `getPartialTag` was still ASCII-only. The two disagreed about what counts as a tag, so a tag the app happily stored, displayed and filtered could never be offered by the autocomplete. The only way to reuse one was to retype it in full from memory.

Two guards were at fault, and the walk-back fired first. Scanning back from the cursor in `#工作`, the first character tested is `作`, `/\w/` rejects it, and the function returns `null` before it ever reaches the `#`. The partial test `/^[a-zA-Z]\w*$/` would have rejected it anyway.

## A second bug fell out of the same cause

`\w` excludes `/`, so the mismatch also broke completion of **nested** tags. Typing `#work/de` stopped the scan at the slash, which means `#work/deep` was uncompletable for ASCII users too. That wasn't in the original issue; it surfaced while writing the tests.

## The fix

Define the tag alphabet once in `taskUtils.js` and export it. `extractTags` decides what **is** a tag; `getPartialTag` decides what can be **completed**. Both now build from the same source, so they cannot drift apart again, which is the actual root cause rather than just its symptom.

No behaviour change for tags that already worked.

## Coverage

New `src/utils/tagAutocomplete.test.js` asserts extraction and completion agree across CJK, accented Latin, Cyrillic, Greek, ASCII, nested, hyphenated and underscored tags, and that all three reject a tag not starting with a letter. It also covers partial completion of a non-Latin tag, completion past the slash in a nested tag, and `getFilteredTags` offering non-Latin tags by prefix.

## Validation

- Full suite: 3,720 passing, up from 3,703
- `eslint` clean on all three touched files

## Credit

Surfaced while reviewing @Lcub3d's Todoist integration (#1604). They write in Chinese, which is how a bug that had been sitting in an ASCII-only regex became visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8k44pwgABpWA4bzd7RPm5

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8k44pwgABpWA4bzd7RPm5)_