### PR TITLE
Move the Todoist sync cache to IndexedDB, keep receipts local

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,15 @@ Rules that are load-bearing rather than stylistic, each covered by tests:
 - **Writeback is guarded and one-way.** Only ordinary non-recurring leaf tasks
   are closed, with durable command UUIDs written before the request so a retry
   cannot double-close. Nothing else is ever sent to Todoist.
-- **The cache is pruned before every persist.** It shares a ~5 MiB localStorage
-  budget with everything else, so inactive records that nothing references are
-  dropped (`pruneCache`).
+- **The cache is pruned before every persist.** Inactive records that nothing
+  references are dropped (`pruneCache`), so accumulated history stays bounded.
+- **Account state is split across two homes, on purpose.** The cache is bulk
+  derived data and lives in IndexedDB; the completion receipts, `lastSync` and
+  `report` stay in localStorage. That is not an oversight to tidy up: a command
+  UUID is written BEFORE its request goes out so a retry after a crash reuses it
+  and cannot close a task twice, and only a synchronous write is durable the
+  moment it returns. Use `readAccountState` / `writeAccountState`; do not reach
+  for `stateKey` directly.
 
 Strings live in the normal locale bundles under the `todoist` prefix, not in a
 feature-local namespace. Add new keys to `public/locales/*/translation.json`;

--- a/src/hooks/useTodoistSync.js
+++ b/src/hooks/useTodoistSync.js
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { DEFAULT_SETTINGS, normalizeSettings, mergeResponse, matches, active, linked,
   reconcileLists, pruneCache, prepareOutbox, acknowledge, writebackReason } from '../todoist/core.js';
-import { requestSync, connectAccount, CONFIG_KEY, TOKEN_KEY, ACCOUNT_KEY, stateKey, readJSON, writeJSON, clearIdleCache } from '../todoist/client.js';
+import { requestSync, connectAccount, CONFIG_KEY, TOKEN_KEY, ACCOUNT_KEY, readJSON, writeJSON,
+  readAccountState, writeAccountState, clearIdleCache } from '../todoist/client.js';
 import { applyPlannedList } from '../utils/todoistReconciliation.js';
 import { isResetInProgress } from '../utils/resetAppData.js';
 
@@ -64,12 +65,12 @@ export default function useTodoistSync({ tasks, setTasks, unscheduledTasks, setU
     setStatus('syncing');
 
     try {
-      const clear = () => id ? clearIdleCache(localStorage, id) : 0;
+      const clear = async () => (id ? clearIdleCache(localStorage, id) : 0);
       // Wait for any in-flight writer, including another tab, before deciding
       // whether the account has receipts that must survive disconnect.
-      const remaining = navigator.locks?.request
-        ? await navigator.locks.request('dayglance-todoist-sync', clear)
-        : clear();
+      const remaining = await (navigator.locks?.request
+        ? navigator.locks.request('dayglance-todoist-sync', clear)
+        : clear());
       setPending(remaining);
       setStatus('idle');
     } catch (err) {
@@ -97,11 +98,11 @@ export default function useTodoistSync({ tasks, setTasks, unscheduledTasks, setU
     setStatus('syncing'); setError('');
     const execute = async () => {
       let id = initial.account;
-      let stored = id ? readJSON(localStorage, stateKey(id), {}) : {};
+      let stored = id ? await readAccountState(id) : {};
       let cache;
       if (mode === 'connect') {
         const connected = await connectAccount(secret,
-          accountId => readJSON(localStorage, stateKey(accountId), {}), { signal: controller.current.signal });
+          accountId => readAccountState(accountId), { signal: controller.current.signal });
         cache = connected.cache; stored = connected.stored;
       } else {
         cache = mergeResponse(stored.cache, await requestSync(secret, stored.cache?.cursor || '*', [],
@@ -123,7 +124,10 @@ export default function useTodoistSync({ tasks, setTasks, unscheduledTasks, setU
       if (stored.queue != null && !Array.isArray(stored.queue)) throw new Error('storageCorrupt');
       let queue = stored.queue || [];
       let currentReport = stored.report || null;
-      const persist = (lastSync = stored.lastSync) => {
+      // Async because the cache half now lands in IndexedDB. The receipts half is
+      // still written synchronously inside writeAccountState, so a durable UUID is
+      // on disk before its request goes out even if this promise never settles.
+      const persist = async (lastSync = stored.lastSync) => {
         check();
         const current = latest.current;
         const retainIds = new Set(
@@ -135,10 +139,10 @@ export default function useTodoistSync({ tasks, setTasks, unscheduledTasks, setU
           if (operation.accountId === id) retainIds.add(String(operation.args.id));
         }
         cache = pruneCache(cache, retainIds);
-        writeJSON(localStorage, stateKey(id), { cache, queue, lastSync, report: currentReport });
+        await writeAccountState(id, { cache, queue, lastSync, report: currentReport });
         setCatalog(cache); setPending(queue.length);
       };
-      persist();
+      await persist();
       if (mode === 'sync') {
         const current = latest.current;
         const all = [...current.tasks, ...current.unscheduledTasks];
@@ -148,7 +152,7 @@ export default function useTodoistSync({ tasks, setTasks, unscheduledTasks, setU
           if (!navigator.locks?.request) throw new Error('writeLockUnavailable');
           const prepared = prepareOutbox(queue, all, cache, current.settings, () => crypto.randomUUID());
           queue = prepared.queue;
-          persist(); // Durable UUIDs BEFORE the request: retry never generates a new close.
+          await persist(); // Durable UUIDs BEFORE the request: retry never generates a new close.
           if (prepared.send.length) {
             check();
             const written = await requestSync(secret, cache.cursor, prepared.send, { signal: controller.current.signal });
@@ -160,9 +164,9 @@ export default function useTodoistSync({ tasks, setTasks, unscheduledTasks, setU
             for (const op of prepared.send) {
               if (ack.succeeded.has(op.uuid)) cache.items[op.args.id] = { ...cache.items[op.args.id], checked: true };
             }
-            persist();
+            await persist();
             cache = mergeResponse(cache, written);
-            persist();
+            await persist();
             if (ack.failed.length) throw new Error('commandFailed');
           }
         }
@@ -180,7 +184,7 @@ export default function useTodoistSync({ tasks, setTasks, unscheduledTasks, setU
         currentState.setUnscheduledTasks(prev => valid() ? applyPlannedList(prev, currentState.unscheduledTasks, plan.unscheduledTasks) : prev);
         currentReport = plan.report;
         setReport(currentReport);
-        persist(now);
+        await persist(now);
         setLastSynced(now);
       } else { setLastSynced(stored.lastSync || null); setReport(currentReport); }
       setCatalog(cache); setPending(queue.length); setStatus('success');

--- a/src/hooks/useTodoistSync.test.js
+++ b/src/hooks/useTodoistSync.test.js
@@ -29,7 +29,10 @@ vi.mock('../todoist/client.js', async importOriginal => ({
   requestSync: (...args) => request(...args),
 }));
 const { default: useTodoistSync } = await import('./useTodoistSync.js');
-const { ACCOUNT_KEY, TOKEN_KEY, CONFIG_KEY, stateKey } = await import('../todoist/client.js');
+const { ACCOUNT_KEY, TOKEN_KEY, CONFIG_KEY, stateKey, cacheKey } = await import('../todoist/client.js');
+// The cache half lives in IndexedDB. jsdom has none, so the store falls back to
+// localStorage under its own key — which is what these assertions read.
+const storedCache = id => JSON.parse(localStorage.getItem(cacheKey(id)));
 const { normalizeSettings, mergeResponse, importTask } = await import('../todoist/core.js');
 
 const remote = patch => ({ id: 'task', content: 'Task', priority: 4, checked: false, is_deleted: false, ...patch });
@@ -93,8 +96,7 @@ describe('Todoist review wiring', () => {
     const h = harness({ inbox: [task] });
     request.mockResolvedValue(response([remote({ checked: true }), remote({ id: 'unlinked', checked: true })]));
     expect(await h.render().syncNow()).toBe(true);
-    const stored = JSON.parse(localStorage.getItem(stateKey('account')));
-    expect(Object.keys(stored.cache.items)).toEqual(['task']);
+    expect(Object.keys(storedCache('account').items)).toEqual(['task']);
     expect(h.state.inbox[0].completed).toBe(true);
     expect(h.setRecycleBin).not.toHaveBeenCalled();
   });
@@ -104,9 +106,8 @@ describe('Todoist review wiring', () => {
     request.mockResolvedValue(response([remote({ id: 'queued', checked: true })]));
     const h = harness();
     expect(await h.render().preview()).toBe(true);
-    const stored = JSON.parse(localStorage.getItem(stateKey('account')));
-    expect(stored.cache.items.queued.checked).toBe(true);
-    expect(stored.queue).toEqual(queue);
+    expect(storedCache('account').items.queued.checked).toBe(true);
+    expect(JSON.parse(localStorage.getItem(stateKey('account'))).queue).toEqual(queue);
   });
   it('disconnect removes credentials and an idle cache, but keeps imported tasks', async () => {
     localStorage.setItem(stateKey('account'), JSON.stringify({ cache: {}, queue: [] }));
@@ -136,7 +137,9 @@ describe('Todoist review wiring', () => {
     const h = harness();
     const api = h.render();
     const syncing = api.syncNow();
-    await Promise.resolve();
+    // Reading the persisted state is async now, so the request is a few
+    // microtasks further in than it used to be.
+    for (let i = 0; i < 8; i++) await Promise.resolve();
     expect(request).toHaveBeenCalledOnce();
     const disconnecting = api.disconnect();
     release(response([remote()]));

--- a/src/todoist/cache.test.js
+++ b/src/todoist/cache.test.js
@@ -1,7 +1,8 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { pruneCache, mergeResponse, importTask, reconcileLists, normalizeSettings } from './core.js';
-import { clearIdleCache, stateKey } from './client.js';
+import { clearIdleCache, stateKey, cacheKey, readAccountState, writeAccountState } from './client.js';
+import { createMemoryKeyValue } from '../utils/idbKeyValue.js';
 
 const item = (id, patch = {}) => ({ id, content: 'Task', priority: 4, checked: false, is_deleted: false, ...patch });
 const cache = items => mergeResponse({}, {
@@ -65,39 +66,94 @@ describe('Todoist cache retention', () => {
   });
 });
 
+describe('Account state is split across two homes', () => {
+  // The cache is bulk derived data and belongs in IndexedDB. The receipts are
+  // tiny and safety-critical: a command UUID must be durable BEFORE its request
+  // goes out, so they stay in synchronous localStorage.
+  it('writes the cache to the store and the receipts to localStorage', async () => {
+    const kv = createMemoryKeyValue();
+    const store = storage({});
+    await writeAccountState('a', { cache: cache([item('x')]), queue: [{ uuid: 'u' }], lastSync: 'now' }, store, kv);
+
+    const receipts = JSON.parse(store.getItem(stateKey('a')));
+    assert.deepEqual(receipts, { queue: [{ uuid: 'u' }], lastSync: 'now' });
+    assert.equal(receipts.cache, undefined); // the bulk is NOT in localStorage
+    assert.ok((await kv.get(cacheKey('a'))).items.x);
+  });
+
+  it('reads the two halves back as one object', async () => {
+    const kv = createMemoryKeyValue();
+    const store = storage({});
+    await writeAccountState('a', { cache: cache([item('x')]), queue: [], lastSync: 'now' }, store, kv);
+    const read = await readAccountState('a', store, kv);
+    assert.equal(read.lastSync, 'now');
+    assert.ok(read.cache.items.x);
+  });
+
+  it('adopts a pre-split blob and strips the cache from localStorage', async () => {
+    const kv = createMemoryKeyValue();
+    const legacy = { cache: cache([item('x')]), queue: [{ uuid: 'u' }], lastSync: 'before' };
+    const store = storage({ [stateKey('a')]: JSON.stringify(legacy) });
+
+    const read = await readAccountState('a', store, kv);
+    assert.ok(read.cache.items.x);          // the caller sees no difference
+    assert.equal(read.lastSync, 'before');
+    // ...but the bytes actually moved, which is the point of the migration.
+    assert.equal(JSON.parse(store.getItem(stateKey('a'))).cache, undefined);
+    assert.deepEqual(JSON.parse(store.getItem(stateKey('a'))).queue, [{ uuid: 'u' }]);
+    assert.ok((await kv.get(cacheKey('a'))).items.x);
+  });
+
+  it('returns an empty state for an account it has never seen', async () => {
+    assert.deepEqual(await readAccountState('nobody', storage({}), createMemoryKeyValue()), {});
+  });
+});
+
 describe('Disconnect cache cleanup', () => {
-  it('clears an idle account cache and leaves other accounts and imported tasks alone', () => {
+  it('clears an idle account cache and leaves other accounts and imported tasks alone', async () => {
+    const kv = createMemoryKeyValue();
     const store = storage({
-      [stateKey('a')]: JSON.stringify({ cache: cache([]), queue: [], lastSync: 'before' }),
+      [stateKey('a')]: JSON.stringify({ queue: [], lastSync: 'before' }),
       [stateKey('b')]: 'other-account',
       'day-planner-tasks': '[{"id":"local"}]',
     });
-    assert.equal(clearIdleCache(store, 'a'), 0);
+    await kv.set(cacheKey('a'), cache([]));
+    await kv.set(cacheKey('b'), cache([]));
+
+    assert.equal(await clearIdleCache(store, 'a', kv), 0);
     assert.equal(store.getItem(stateKey('a')), null);
+    assert.equal(await kv.get(cacheKey('a')), undefined);   // both homes cleared
     assert.equal(store.getItem(stateKey('b')), 'other-account');
+    assert.ok(await kv.get(cacheKey('b')));                 // the other account is untouched
     assert.equal(store.getItem('day-planner-tasks'), '[{"id":"local"}]');
   });
-  it('preserves the entire pending receipt, including the original request UUID', () => {
-    const raw = JSON.stringify({ cache: cache([]), queue: [{ uuid: 'original-uuid', args: { id: 'task' } }] });
+  it('preserves the entire pending receipt, including the original request UUID', async () => {
+    const kv = createMemoryKeyValue();
+    const raw = JSON.stringify({ queue: [{ uuid: 'original-uuid', args: { id: 'task' } }] });
     const store = storage({ [stateKey('a')]: raw });
-    assert.equal(clearIdleCache(store, 'a'), 1);
+    await kv.set(cacheKey('a'), cache([]));
+
+    assert.equal(await clearIdleCache(store, 'a', kv), 1);
     assert.equal(store.getItem(stateKey('a')), raw);
+    // The cache survives too: a retained queue means this account is expected back.
+    assert.ok(await kv.get(cacheKey('a')));
   });
-  it('clears a legacy cache with no queue and tolerates missing cache keys', () => {
+  it('clears a legacy cache with no queue and tolerates missing cache keys', async () => {
+    const kv = createMemoryKeyValue();
     const store = storage({ [stateKey('a')]: JSON.stringify({ cache: cache([]) }) });
-    assert.equal(clearIdleCache(store, 'a'), 0);
-    assert.equal(clearIdleCache(store, 'missing'), 0);
+    assert.equal(await clearIdleCache(store, 'a', kv), 0);
+    assert.equal(await clearIdleCache(store, 'missing', kv), 0);
   });
-  it('fails closed on corrupt queue data instead of dropping possible receipts', () => {
+  it('fails closed on corrupt queue data instead of dropping possible receipts', async () => {
     for (const raw of ['broken JSON', 'null', '[]', '{"queue":{}}']) {
       const store = storage({ [stateKey('a')]: raw });
-      assert.throws(() => clearIdleCache(store, 'a'), /storageCorrupt/);
+      await assert.rejects(() => clearIdleCache(store, 'a', createMemoryKeyValue()), /storageCorrupt/);
       assert.equal(store.getItem(stateKey('a')), raw);
     }
   });
-  it('reports an unavailable storage write without pretending cleanup succeeded', () => {
+  it('reports an unavailable storage write without pretending cleanup succeeded', async () => {
     const store = storage({});
     store.removeItem = () => { throw new Error('denied'); };
-    assert.throws(() => clearIdleCache(store, 'a'), /storageFull/);
+    await assert.rejects(() => clearIdleCache(store, 'a', createMemoryKeyValue()), /storageFull/);
   });
 });

--- a/src/todoist/client.js
+++ b/src/todoist/client.js
@@ -1,4 +1,5 @@
 import { mergeResponse } from './core.js';
+import { createIdbKeyValue } from '../utils/idbKeyValue.js';
 // No proxy, configurable host, telemetry, token-in-URL, or logged response body.
 export const TODOIST_ENDPOINT = 'https://api.todoist.com/api/v1/sync';
 export async function requestSync(token, cursor = '*', commands = [], { signal, fetchImpl = globalThis.fetch } = {}) {
@@ -37,6 +38,54 @@ export const CONFIG_KEY = 'dg-todoist-config-v1';
 export const TOKEN_KEY = 'dg-todoist-token-v1';
 export const ACCOUNT_KEY = 'dg-todoist-account-v1';
 export const stateKey = id => `dg-todoist-state-v1:${id}`;
+export const cacheKey = id => `dg-todoist-cache-v1:${id}`;
+
+// WHERE THE ACCOUNT STATE LIVES, AND WHY IT IS SPLIT
+//
+// The per-account blob is two very different things wearing one key:
+//
+//   cache   every active item, project and label read from Todoist. This is
+//           the bulk — hundreds of kilobytes on a large account — and it is
+//           pure derived data: losing it costs one full re-read, nothing more.
+//
+//   queue   durable receipts for completion commands, plus lastSync/report.
+//           Bytes, not kilobytes.
+//
+// The cache moves to IndexedDB, where the quota is a share of disk rather than
+// the ~5 MiB localStorage budget it was sharing with the user's actual tasks.
+//
+// The receipts DELIBERATELY do not. A command UUID is written BEFORE its
+// request goes out, precisely so a retry after a crash reuses the same UUID and
+// cannot close a task twice. localStorage writes are synchronous and durable the
+// moment they return; an IndexedDB write is a promise that a crash can outrun.
+// Moving the receipts would trade a real safety property for a few hundred bytes.
+const cacheStore = createIdbKeyValue('dayglance-todoist');
+
+/**
+ * Read the account's persisted state, transparently migrating a pre-split blob.
+ * Returns the same `{ cache, queue, lastSync, report }` shape as before.
+ */
+export async function readAccountState(accountId, storage = localStorage, store = cacheStore) {
+  const receipts = readJSON(storage, stateKey(accountId), {});
+  if (!receipts || typeof receipts !== 'object' || Array.isArray(receipts)) throw new Error('storageCorrupt');
+  // Pre-split installs still carry the cache inside the localStorage blob. Adopt
+  // it once, then strip it so the bytes are actually reclaimed.
+  if (receipts.cache) {
+    const { cache, ...rest } = receipts;
+    await store.set(cacheKey(accountId), cache);
+    writeJSON(storage, stateKey(accountId), rest);
+    return { ...rest, cache };
+  }
+  const cache = await store.get(cacheKey(accountId));
+  return cache ? { ...receipts, cache } : receipts;
+}
+
+/** Persist the account's state, cache and receipts to their own homes. */
+export async function writeAccountState(accountId, { cache, ...receipts }, storage = localStorage, store = cacheStore) {
+  // Receipts first: if the cache write fails, the durable half is already down.
+  writeJSON(storage, stateKey(accountId), receipts);
+  if (cache) await store.set(cacheKey(accountId), cache);
+}
 export function readJSON(storage, key, fallback) {
   const raw = storage.getItem(key);
   if (!raw) return fallback;
@@ -50,7 +99,7 @@ export function writeJSON(storage, key, value) {
 // completions received while the app was closed. Never write during connect.
 export async function connectAccount(token, loadStored, options = {}) {
   const fresh = mergeResponse({}, await requestSync(token, '*', [], options));
-  const stored = loadStored(String(fresh.user.id));
+  const stored = await loadStored(String(fresh.user.id));
   const base = stored.cache?.cursor ? stored.cache : fresh;
   const cache = mergeResponse(base, await requestSync(token, base.cursor, [], options));
   if (String(cache.user.id) !== String(fresh.user.id)) throw new Error('accountChanged');
@@ -59,7 +108,7 @@ export async function connectAccount(token, loadStored, options = {}) {
 
 // Returns the number of unconfirmed receipts. A pending queue is deliberately
 // not erased: after reconnecting, retries must reuse the original UUIDs.
-export function clearIdleCache(storage, accountId) {
+export async function clearIdleCache(storage, accountId, store = cacheStore) {
   const key = stateKey(accountId);
   const stored = readJSON(storage, key, {});
   if (!stored || typeof stored !== 'object' || Array.isArray(stored)
@@ -69,6 +118,10 @@ export function clearIdleCache(storage, accountId) {
   const pending = stored.queue?.length || 0;
   if (pending === 0) {
     try { storage.removeItem(key); } catch { throw new Error('storageFull'); }
+    // The cache is worth dropping even while receipts remain — it is the large,
+    // rebuildable half — but keeping the two in step is simpler to reason about,
+    // and a retained queue means the user is expected back on this account.
+    await store.del(cacheKey(accountId));
   }
   return pending;
 }


### PR DESCRIPTION
Refs #1626, #1627. Follows #1629, and reuses the store it introduced.

## The split, and why it isn't a full move

`dg-todoist-state-v1:<id>` was two very different things wearing one key:

| | what it is | size |
|---|---|---|
| `cache` | every active item, project and label read from Todoist | hundreds of KB on a large account |
| `queue`, `lastSync`, `report` | durable completion receipts and cursors | bytes |

**Only the cache moves.** It is pure derived data: losing it costs one full re-read and nothing else, and it was the part actually consuming the budget.

**The receipts deliberately stay in localStorage.** A command UUID is written *before* its request goes out, precisely so a retry after a crash reuses it and cannot close a task twice. Only a synchronous write is durable the moment it returns; an IndexedDB write is a promise a crash can outrun. Moving the receipts would trade a real safety property for a few hundred bytes.

`readAccountState` / `writeAccountState` hide the split, so callers see the same `{ cache, queue, lastSync, report }` shape as before, and a pre-split blob is adopted and stripped on first read.

## Effect on #1626

With the snapshot already relocated in #1629, this removes the second large localStorage consumer the integration added. Using your install as the yardstick (~750 bytes per task):

| Active Todoist tasks | before #1629 | after both |
|---|---|---|
| 1,000 | ~1.3 MB | ~0.75 MB |
| 3,000 | ~3.9 MB | ~2.25 MB |

What remains is the imported tasks themselves, which are ordinary user data subject to exactly the same limits as any other dayGLANCE task. That makes #1626 a general task-count question rather than a Todoist one, which is the argument for closing it in favour of #1627's follow-on work rather than adding a preview warning.

## Coverage

New `Account state is split across two homes` in `cache.test.js`: the cache lands in the store and **not** in localStorage, the two halves read back as one object, a pre-split blob is adopted and the bytes actually reclaimed, and an unseen account reads as empty.

The existing disconnect tests are updated to assert both homes are cleared, that another account is untouched, and that a retained queue keeps its cache. `clearIdleCache` is now async, so its fail-closed cases use `assert.rejects`.

## Two things worth flagging from the work

**A bug I introduced and caught.** Making `clear()` async left `: clear()` unawaited in the non-Web-Locks branch of `disconnect`, which would have set `pending` to a Promise. Lint didn't flag it. Fixed by awaiting the whole expression.

**A `CLAUDE.md` claim this falsifies.** It said the cache "shares a ~5 MiB localStorage budget with everything else". Updated in the same commit, along with a note on why the split exists so nobody tidies the receipts into IndexedDB later.

## Validation

- Full suite: 3,742 passing, up from 3,738
- `eslint src/` clean
- Production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8k44pwgABpWA4bzd7RPm5

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8k44pwgABpWA4bzd7RPm5)_