### PR TITLE
Storage gauge: say what it measures, and show the other half

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -1177,12 +1177,13 @@
     "matchIn": "in {{field}}"
   },
   "storage": {
-    "todoistCache": "Todoist-Synchronisierungscache",
+    "database": "Synchronisierungs-Caches: {{used}}, getrennt gespeichert und oben nicht mitgezählt.",
     "deletionTombstones": "Löschmarkierungen",
     "habitLogs": "Gewohnheitsprotokolle",
     "importedCalendarEvents": "Importierte Kalenderereignisse",
     "title": "Speicherbelegung",
-    "total": "Gesamt: {{used}} / ca. 5 MB ({{percent}} %)"
+    "todoistReceipts": "Ausstehende Todoist-Vorgänge",
+    "total": "Lokaler Speicher: {{used}} / ca. 5 MB ({{percent}} %)"
   },
   "weeklyReview": {
     "durationMinutes": "{{minutes}} Min.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1177,12 +1177,13 @@
     "matchIn": "in {{field}}"
   },
   "storage": {
-    "todoistCache": "Todoist sync cache",
+    "database": "Sync caches: {{used}}, stored separately and not counted above.",
     "deletionTombstones": "Deletion tombstones",
     "habitLogs": "Habit logs",
     "importedCalendarEvents": "Imported calendar events",
     "title": "Storage Breakdown",
-    "total": "Total: {{used}} / ~5 MB ({{percent}}%)"
+    "todoistReceipts": "Todoist pending operations",
+    "total": "Local storage: {{used}} / ~5 MB ({{percent}}%)"
   },
   "weeklyReview": {
     "durationMinutes": "{{minutes}}m",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1177,12 +1177,13 @@
     "matchIn": "en {{field}}"
   },
   "storage": {
-    "todoistCache": "Caché de sincronización de Todoist",
+    "database": "Cachés de sincronización: {{used}}, se guardan aparte y no se cuentan arriba.",
     "deletionTombstones": "Marcas de eliminación",
     "habitLogs": "Registros de hábitos",
     "importedCalendarEvents": "Eventos de calendario importados",
     "title": "Desglose del almacenamiento",
-    "total": "Total: {{used}} / ~5 MB ({{percent}} %)"
+    "todoistReceipts": "Operaciones pendientes de Todoist",
+    "total": "Almacenamiento local: {{used}} / ~5 MB ({{percent}}%)"
   },
   "weeklyReview": {
     "durationMinutes": "{{minutes}} min",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1177,12 +1177,13 @@
     "matchIn": "dans {{field}}"
   },
   "storage": {
-    "todoistCache": "Cache de synchronisation Todoist",
+    "database": "Caches de synchronisation : {{used}}, stockés séparément et non comptés ci-dessus.",
     "deletionTombstones": "Marqueurs de suppression",
     "habitLogs": "Journaux des habitudes",
     "importedCalendarEvents": "Événements de calendrier importés",
     "title": "Répartition du stockage",
-    "total": "Total : {{used}} / env. 5 Mo ({{percent}} %)"
+    "todoistReceipts": "Opérations Todoist en attente",
+    "total": "Stockage local : {{used}} / ~5 Mo ({{percent}} %)"
   },
   "weeklyReview": {
     "durationMinutes": "{{minutes}} min",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -1177,12 +1177,13 @@
     "matchIn": "in {{field}}"
   },
   "storage": {
-    "todoistCache": "Cache di sincronizzazione Todoist",
+    "database": "Cache di sincronizzazione: {{used}}, salvate a parte e non conteggiate sopra.",
     "deletionTombstones": "Marcatori di eliminazione",
     "habitLogs": "Registri delle abitudini",
     "importedCalendarEvents": "Eventi del calendario importati",
     "title": "Dettaglio dello spazio di archiviazione",
-    "total": "Totale: {{used}} / circa 5 MB ({{percent}}%)"
+    "todoistReceipts": "Operazioni Todoist in sospeso",
+    "total": "Archivio locale: {{used}} / ~5 MB ({{percent}}%)"
   },
   "weeklyReview": {
     "durationMinutes": "{{minutes}} min",

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -1177,12 +1177,13 @@
     "matchIn": "em {{field}}"
   },
   "storage": {
-    "todoistCache": "Cache de sincronização do Todoist",
+    "database": "Caches de sincronização: {{used}}, guardados à parte e não contados acima.",
     "deletionTombstones": "Marcas de exclusão",
     "habitLogs": "Registros de hábitos",
     "importedCalendarEvents": "Eventos de calendário importados",
     "title": "Detalhamento do armazenamento",
-    "total": "Total: {{used}} / ~5 MB ({{percent}}%)"
+    "todoistReceipts": "Operações pendentes do Todoist",
+    "total": "Armazenamento local: {{used}} / ~5 MB ({{percent}}%)"
   },
   "weeklyReview": {
     "durationMinutes": "{{minutes}} min",

--- a/public/locales/pt-PT/translation.json
+++ b/public/locales/pt-PT/translation.json
@@ -1177,12 +1177,13 @@
     "matchIn": "em {{field}}"
   },
   "storage": {
-    "todoistCache": "Cache de sincronização do Todoist",
+    "database": "Caches de sincronização: {{used}}, guardadas à parte e não contadas acima.",
     "deletionTombstones": "Marcadores de eliminação",
     "habitLogs": "Registos de hábitos",
     "importedCalendarEvents": "Eventos de calendário importados",
     "title": "Detalhes do armazenamento",
-    "total": "Total: {{used}} / ~5 MB ({{percent}}%)"
+    "todoistReceipts": "Operações pendentes do Todoist",
+    "total": "Armazenamento local: {{used}} / ~5 MB ({{percent}}%)"
   },
   "weeklyReview": {
     "durationMinutes": "{{minutes}} min",

--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -1177,12 +1177,13 @@
     "matchIn": "在{{field}}中"
   },
   "storage": {
-    "todoistCache": "Todoist 同步缓存",
+    "database": "同步缓存：{{used}}，单独存储，不计入上方限额。",
     "deletionTombstones": "删除标记",
     "habitLogs": "习惯日志",
     "importedCalendarEvents": "导入的日历事件",
     "title": "存储空间明细",
-    "total": "总计：{{used}} / 约 5 MB（{{percent}}%）"
+    "todoistReceipts": "Todoist 待处理操作",
+    "total": "本地存储：{{used}} / 约 5 MB（{{percent}}%）"
   },
   "weeklyReview": {
     "durationMinutes": "{{minutes}} 分钟",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10058,7 +10058,7 @@ const DayPlanner = () => {
                       className={`flex items-center gap-1.5 text-xs ${warn ? 'text-orange-500' : textSecondary} hover:opacity-75 transition-opacity w-full`}
                     >
                       {warn && <AlertTriangle size={11} />}
-                      Storage: {formatBytes(su.totalBytes)} / ~5 MB
+                      Local storage: {formatBytes(su.totalBytes)} / ~5 MB
                     </button>
                   );
                 })()}

--- a/src/components/StorageBreakdownModal.jsx
+++ b/src/components/StorageBreakdownModal.jsx
@@ -1,21 +1,35 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { AlertTriangle, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useDayPlannerCtx } from '../context/DayPlannerContext.jsx';
 import { useSyncCtx } from '../context/SyncContext.jsx';
-import { getStorageUsage, formatBytes } from '../utils/storage.js';
+import { getStorageUsage, getIndexedDbUsage, formatBytes } from '../utils/storage.js';
 
 const StorageBreakdownModal = () => {
   const { t } = useTranslation();
   const { cardBg, borderClass, textPrimary, textSecondary, darkMode, hoverBg } = useDayPlannerCtx();
   const { showStorageBreakdown, setShowStorageBreakdown } = useSyncCtx();
+  // null means the browser will not separate IndexedDB from the service worker
+  // precache in its estimate, NOT that IndexedDB is empty. The line is omitted
+  // rather than showing a total that is mostly application bundle.
+  const [databaseBytes, setDatabaseBytes] = useState(null);
+
+  useEffect(() => {
+    if (!showStorageBreakdown) return undefined;
+    let live = true;
+    getIndexedDbUsage().then((bytes) => { if (live) setDatabaseBytes(bytes); });
+    return () => { live = false; };
+  }, [showStorageBreakdown]);
 
   if (!showStorageBreakdown) return null;
 
   const { totalBytes, entries } = getStorageUsage();
   const warn = totalBytes > 4 * 1024 * 1024;
   const labels = {
-    'dg-todoist-state-v1': t('storage.todoistCache'),
+    // The Todoist CACHE moved to IndexedDB; this key now holds only the pending
+    // completion receipts, which are deliberately left in localStorage so a
+    // command UUID is durable before its request goes out.
+    'dg-todoist-state-v1': t('storage.todoistReceipts'),
     'day-planner-tasks': t('reminders.scheduledTasks'),
     'day-planner-tasks:user': t('reminders.scheduledTasks'),
     'day-planner-tasks:imported': t('storage.importedCalendarEvents', { defaultValue: 'Imported calendar events' }),
@@ -45,13 +59,19 @@ const StorageBreakdownModal = () => {
                 {t('storage.total', {
                   used: formatBytes(totalBytes),
                   percent: (totalBytes / (5 * 1024 * 1024) * 100).toFixed(0),
-                  defaultValue: 'Total: {{used}} / ~5 MB ({{percent}}%)',
                 })}
               </div>
-              {/* Progress bar */}
+              {/* Progress bar. ~5 MiB is hardcoded because no API reports the real
+                  localStorage cap; it is the lowest common denominator across the
+                  targets, the tightest being the iOS and Android webviews. */}
               <div className={`w-full h-2 rounded-full ${darkMode ? 'bg-gray-700' : 'bg-stone-200'} mb-4`}>
                 <div className={`h-full rounded-full transition-all ${warn ? 'bg-orange-500' : 'bg-blue-500'}`} style={{ width: `${Math.min(100, totalBytes / (5 * 1024 * 1024) * 100)}%` }} />
               </div>
+              {databaseBytes != null && (
+                <div className={`text-xs mb-4 ${textSecondary}`}>
+                  {t('storage.database', { used: formatBytes(databaseBytes) })}
+                </div>
+              )}
               <div className="space-y-1.5">
                 {entries.filter(k => k.bytes > 100).map(({ key, bytes, count }) => (
                   <div key={key} className="flex items-center justify-between text-xs">

--- a/src/components/StorageBreakdownModal.test.jsx
+++ b/src/components/StorageBreakdownModal.test.jsx
@@ -37,11 +37,17 @@ describe('Todoist storage breakdown label', () => {
         </DayPlannerContext.Provider>
       </I18nextProvider>,
     );
-    expect(bundle.storage.todoistCache).toBeTypeOf('string');
-    expect(html.split(bundle.storage.todoistCache)).toHaveLength(3);
+    // The key now holds pending completion receipts, not the cache: the cache
+    // itself moved to IndexedDB.
+    expect(bundle.storage.todoistReceipts).toBeTypeOf('string');
+    expect(html.split(bundle.storage.todoistReceipts)).toHaveLength(3);
     expect(html).toContain(bundle.storage.title);
     expect(html).not.toContain('dg-todoist-state-v1');
     expect(html).not.toContain('todoist:storageCache');
     expect(html).toContain('unrelated-cache');
+    // The IndexedDB line stays absent until a real figure arrives, so a browser
+    // that will not break the estimate out shows nothing rather than a number
+    // that is mostly service worker precache.
+    expect(html).not.toContain(bundle.storage.database.split('{{')[0].trim());
   });
 });

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,4 +1,9 @@
-// Compute localStorage usage with per-key breakdown
+// Compute localStorage usage with per-key breakdown.
+//
+// This measures localStorage ONLY, which is deliberate: it is the tier with a
+// real ceiling (~5 MiB per origin, and synchronous so it never grows with the
+// machine). Bulk and derived data now lives in IndexedDB, where the quota is a
+// share of free disk. See getIndexedDbUsage below for that half.
 export const getStorageUsage = () => {
   const entries = [];
   let totalBytes = 0;
@@ -33,4 +38,31 @@ export const getStorageUsage = () => {
 export const formatBytes = (bytes) => {
   if (bytes > 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   return `${(bytes / 1024).toFixed(0)} KB`;
+};
+
+/**
+ * Bytes IndexedDB is using, or null where the browser will not break it out.
+ *
+ * `navigator.storage.estimate()` reports usage across ALL storage buckets, and
+ * for dayGLANCE that total is dominated by the service worker precache: roughly
+ * 4 MB of application bundle. Showing that figure as app data would be worse
+ * than showing nothing, so this reads the `usageDetails` breakdown instead and
+ * returns null when it is missing.
+ *
+ * `usageDetails` is a Chromium extension. Safari and Firefox return nothing, and
+ * callers are expected to omit the line entirely rather than substitute the
+ * misleading total. Those are also the platforms where localStorage is tightest,
+ * so the meter that matters is unaffected.
+ *
+ * null therefore means "unknown", never "zero".
+ */
+export const getIndexedDbUsage = async () => {
+  try {
+    if (typeof navigator === 'undefined' || !navigator.storage?.estimate) return null;
+    const estimate = await navigator.storage.estimate();
+    const bytes = estimate?.usageDetails?.indexedDB;
+    return typeof bytes === 'number' ? bytes : null;
+  } catch {
+    return null;
+  }
 };

--- a/src/utils/storage.test.js
+++ b/src/utils/storage.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { getIndexedDbUsage } from './storage.js';
+
+// navigator.storage.estimate() reports every storage bucket at once, and for
+// dayGLANCE that total is dominated by the service worker precache: roughly 4 MB
+// of application bundle. Reporting it as app data would be worse than reporting
+// nothing, so only the `usageDetails` breakdown counts, and its absence means
+// "unknown" rather than "zero".
+const withNavigator = (storage) => vi.stubGlobal('navigator', storage ? { storage } : {});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('getIndexedDbUsage', () => {
+  it('reports the IndexedDB figure when the browser breaks it out', async () => {
+    withNavigator({ estimate: async () => ({ usage: 5_000_000, usageDetails: { indexedDB: 1_400_000, caches: 3_600_000 } }) });
+    expect(await getIndexedDbUsage()).toBe(1_400_000);
+  });
+
+  it('returns null rather than the all-bucket total when usageDetails is missing', async () => {
+    // Safari and Firefox. Returning `usage` here would show ~4 MB of app bundle
+    // as though it were the user's data.
+    withNavigator({ estimate: async () => ({ usage: 4_200_000, quota: 10_000_000_000 }) });
+    expect(await getIndexedDbUsage()).toBeNull();
+  });
+
+  it('returns null when usageDetails omits IndexedDB specifically', async () => {
+    withNavigator({ estimate: async () => ({ usage: 4_200_000, usageDetails: { caches: 4_200_000 } }) });
+    expect(await getIndexedDbUsage()).toBeNull();
+  });
+
+  it('distinguishes a genuine zero from unknown', async () => {
+    withNavigator({ estimate: async () => ({ usageDetails: { indexedDB: 0 } }) });
+    expect(await getIndexedDbUsage()).toBe(0);
+  });
+
+  it('returns null where the Storage API is absent entirely', async () => {
+    withNavigator(null);
+    expect(await getIndexedDbUsage()).toBeNull();
+  });
+
+  it('returns null instead of rejecting when estimate throws', async () => {
+    withNavigator({ estimate: async () => { throw new Error('SecurityError'); } });
+    expect(await getIndexedDbUsage()).toBeNull();
+  });
+});


### PR DESCRIPTION
Refs #1627.

## Why

Moving the sync snapshot (#1629) and the Todoist cache (#1630) to IndexedDB didn't shrink that data, it moved it somewhere the gauge can't see. A user watching their total fall from 3.0 MB to 1.5 MB had no way to distinguish a relocation from a loss, and the modal still called the result "Total".

## Three changes

**1. The meter says what it measures.** "Local storage: 1.5 MB / ~5 MB" rather than "Total".

It keeps the ~5 MiB denominator, which I think is right rather than merely convenient. localStorage is the tier with a real ceiling: it's synchronous, so the browser holds it in memory and blocks the main thread on every access, and the limit hasn't moved in fifteen years regardless of disk. There's also no API that reports the actual cap, so a lowest-common-denominator figure across the targets is the honest choice, the tightest being the iOS and Android webviews. That reasoning is now a comment instead of folklore.

**2. A second line reports IndexedDB, where the browser will break it out.**

The trap here is `navigator.storage.estimate().usage`. It sums every storage bucket, and for dayGLANCE that total is dominated by the service worker precache: **4,251 KiB of application bundle**. Reporting it as app data would be actively worse than reporting nothing, since it would look like the user had 4 MB of data they'd never seen.

So only `usageDetails.indexedDB` counts. That's a Chromium extension, so **Safari and Firefox get no line at all** rather than a substituted total. `null` means unknown, never zero. Those happen to be the platforms where localStorage is tightest, so the meter that actually matters is unaffected.

**3. A label this work had falsified.** `dg-todoist-state-v1` was still labelled "Todoist sync cache" after #1630 moved the cache out. That key now holds only the pending completion receipts, which stay in localStorage on purpose. It's relabelled "Todoist pending operations".

## Coverage

New `src/utils/storage.test.js` pins the decision that carries the risk:

- reports the figure when the browser breaks it out
- returns `null` rather than the all-bucket total when `usageDetails` is missing, with a note that returning `usage` would show app bundle as user data
- returns `null` when `usageDetails` omits IndexedDB specifically
- distinguishes a genuine `0` from unknown
- returns `null` when the Storage API is absent, and when `estimate()` throws

The modal test gains an assertion that the IndexedDB line stays absent until a real figure arrives, so the omit-on-Safari behaviour is pinned at the render level too.

## Notes

Three new locale keys across all eight bundles (`storage.total` reworded, `storage.database`, `storage.todoistReceipts`), and `storage.todoistCache` removed since nothing references it now.

`App.jsx` has a second, unlocalised gauge in the About panel; it gets the same relabel and nothing more.

## Validation

- Full suite: 3,748 passing, up from 3,742
- `eslint src/` clean
- Production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8k44pwgABpWA4bzd7RPm5

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8k44pwgABpWA4bzd7RPm5)_