### PR TITLE
Test the IndexedDB store for real, and name the database line honestly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "electronmon": "^2.0.3",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.1.1",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^17.7.0",
         "jimp": "^1.6.1",
         "postcss": "^8.4.27",
@@ -7070,6 +7071,16 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "electronmon": "^2.0.3",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^17.7.0",
     "jimp": "^1.6.1",
     "postcss": "^8.4.27",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -1177,7 +1177,7 @@
     "matchIn": "in {{field}}"
   },
   "storage": {
-    "database": "Synchronisierungs-Caches: {{used}}, getrennt gespeichert und oben nicht mitgezählt.",
+    "database": "Datenbanken: {{used}}, getrennt gespeichert mit einem deutlich größeren Limit.",
     "deletionTombstones": "Löschmarkierungen",
     "habitLogs": "Gewohnheitsprotokolle",
     "importedCalendarEvents": "Importierte Kalenderereignisse",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1177,7 +1177,7 @@
     "matchIn": "in {{field}}"
   },
   "storage": {
-    "database": "Sync caches: {{used}}, stored separately and not counted above.",
+    "database": "Databases: {{used}}, stored separately with a much larger limit.",
     "deletionTombstones": "Deletion tombstones",
     "habitLogs": "Habit logs",
     "importedCalendarEvents": "Imported calendar events",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1177,7 +1177,7 @@
     "matchIn": "en {{field}}"
   },
   "storage": {
-    "database": "Cachés de sincronización: {{used}}, se guardan aparte y no se cuentan arriba.",
+    "database": "Bases de datos: {{used}}, se guardan aparte y con un límite mucho mayor.",
     "deletionTombstones": "Marcas de eliminación",
     "habitLogs": "Registros de hábitos",
     "importedCalendarEvents": "Eventos de calendario importados",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1177,7 +1177,7 @@
     "matchIn": "dans {{field}}"
   },
   "storage": {
-    "database": "Caches de synchronisation : {{used}}, stockés séparément et non comptés ci-dessus.",
+    "database": "Bases de données : {{used}}, stockées séparément avec une limite bien plus élevée.",
     "deletionTombstones": "Marqueurs de suppression",
     "habitLogs": "Journaux des habitudes",
     "importedCalendarEvents": "Événements de calendrier importés",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -1177,7 +1177,7 @@
     "matchIn": "in {{field}}"
   },
   "storage": {
-    "database": "Cache di sincronizzazione: {{used}}, salvate a parte e non conteggiate sopra.",
+    "database": "Database: {{used}}, salvati a parte con un limite molto più ampio.",
     "deletionTombstones": "Marcatori di eliminazione",
     "habitLogs": "Registri delle abitudini",
     "importedCalendarEvents": "Eventi del calendario importati",

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -1177,7 +1177,7 @@
     "matchIn": "em {{field}}"
   },
   "storage": {
-    "database": "Caches de sincronização: {{used}}, guardados à parte e não contados acima.",
+    "database": "Bancos de dados: {{used}}, guardados à parte e com um limite bem maior.",
     "deletionTombstones": "Marcas de exclusão",
     "habitLogs": "Registros de hábitos",
     "importedCalendarEvents": "Eventos de calendário importados",

--- a/public/locales/pt-PT/translation.json
+++ b/public/locales/pt-PT/translation.json
@@ -1177,7 +1177,7 @@
     "matchIn": "em {{field}}"
   },
   "storage": {
-    "database": "Caches de sincronização: {{used}}, guardadas à parte e não contadas acima.",
+    "database": "Bases de dados: {{used}}, guardadas à parte e com um limite muito maior.",
     "deletionTombstones": "Marcadores de eliminação",
     "habitLogs": "Registos de hábitos",
     "importedCalendarEvents": "Eventos de calendário importados",

--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -1177,7 +1177,7 @@
     "matchIn": "在{{field}}中"
   },
   "storage": {
-    "database": "同步缓存：{{used}}，单独存储，不计入上方限额。",
+    "database": "数据库：{{used}}，单独存储，限额大得多。",
     "deletionTombstones": "删除标记",
     "habitLogs": "习惯日志",
     "importedCalendarEvents": "导入的日历事件",

--- a/src/utils/idbKeyValue.idb.test.js
+++ b/src/utils/idbKeyValue.idb.test.js
@@ -1,0 +1,133 @@
+// The IndexedDB path, exercised against a real IndexedDB implementation.
+//
+// WHY THIS FILE IS SEPARATE
+// jsdom ships no IndexedDB, so every other test in the repo runs
+// createIdbKeyValue's localStorage fallback. That left the IndexedDB half —
+// opening the database, creating the object store on upgrade, the transaction
+// and request plumbing — with zero executions anywhere, including CI, while
+// three merged changes came to depend on it.
+//
+// Importing fake-indexeddb/auto installs the globals for THIS FILE ONLY: vitest
+// isolates each test file's environment by default. Installing it globally would
+// be wrong, because the suites that assert on the fallback (idbKeyValue.test.js,
+// the Todoist hook tests, dbEngineWiring) would silently stop testing it.
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { createIdbKeyValue } from './idbKeyValue.js';
+
+function memLocalStorage() {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+// A fresh database name per test: createIdbKeyValue caches one connection per
+// name for the life of the module, which is the behaviour we want in the app and
+// a cross-test leak we do not want here.
+let counter = 0;
+const freshStore = () => createIdbKeyValue(`kv-test-${++counter}`);
+
+beforeEach(() => { global.localStorage = memLocalStorage(); });
+afterAll(() => { delete global.localStorage; });
+
+describe('the IndexedDB path', () => {
+  it('creates its object store and round-trips a value', async () => {
+    // Proves openDatabase resolved a real connection and onupgradeneeded ran:
+    // without the store, the transaction would throw and this would fall back.
+    const store = freshStore();
+    await store.set('baseline', { 'tasks:1': 'hash-a' });
+    expect(await store.get('baseline')).toEqual({ 'tasks:1': 'hash-a' });
+    // ...and it is genuinely in IndexedDB, not the fallback.
+    expect(localStorage.getItem('baseline')).toBeNull();
+  });
+
+  it('stores structured clones, so nesting survives without a JSON round trip', async () => {
+    const store = freshStore();
+    const value = { items: { a: { id: 'a', labels: ['x', 'y'], due: null } }, cursor: 'abc' };
+    await store.set('cache', value);
+    const read = await store.get('cache');
+    expect(read).toEqual(value);
+    expect(read).not.toBe(value); // a clone, not the same reference
+  });
+
+  it('returns undefined for a key that was never written', async () => {
+    expect(await freshStore().get('missing')).toBeUndefined();
+  });
+
+  it('overwrites rather than merging', async () => {
+    const store = freshStore();
+    await store.set('k', { a: 1 });
+    await store.set('k', { b: 2 });
+    expect(await store.get('k')).toEqual({ b: 2 });
+  });
+
+  it('deletes, and a deleted key reads as undefined again', async () => {
+    const store = freshStore();
+    await store.set('k', { a: 1 });
+    await store.del('k');
+    expect(await store.get('k')).toBeUndefined();
+  });
+
+  it('keeps keys independent', async () => {
+    const store = freshStore();
+    await store.set('one', { a: 1 });
+    await store.set('two', { b: 2 });
+    await store.del('one');
+    expect(await store.get('two')).toEqual({ b: 2 });
+  });
+
+  it('keeps databases independent', async () => {
+    const a = freshStore();
+    const b = freshStore();
+    await a.set('shared-key', { from: 'a' });
+    expect(await b.get('shared-key')).toBeUndefined();
+  });
+
+  it('reuses its connection across calls', async () => {
+    // The connection is cached per database name, so a second call must not
+    // re-run the upgrade and lose what the first one wrote.
+    const store = freshStore();
+    await store.set('k', { a: 1 });
+    expect(await store.get('k')).toEqual({ a: 1 });
+    expect(await store.get('k')).toEqual({ a: 1 });
+  });
+});
+
+describe('migrating off localStorage', () => {
+  it('reads a value an older version left in localStorage', async () => {
+    // The read falls through to localStorage when IndexedDB has nothing, which
+    // is what lets the sync snapshot and the Todoist cache carry their existing
+    // state across the upgrade instead of starting cold.
+    localStorage.setItem('legacy', JSON.stringify({ 'tasks:1': 'hash' }));
+    expect(await freshStore().get('legacy')).toEqual({ 'tasks:1': 'hash' });
+  });
+
+  it('clears the localStorage copy once the value is written to IndexedDB', async () => {
+    // Otherwise the bytes are never actually reclaimed, which was the point.
+    const store = freshStore();
+    localStorage.setItem('legacy', JSON.stringify({ old: true }));
+    await store.set('legacy', { migrated: true });
+    expect(localStorage.getItem('legacy')).toBeNull();
+    expect(await store.get('legacy')).toEqual({ migrated: true });
+  });
+
+  it('prefers IndexedDB over a stale localStorage copy', async () => {
+    const store = freshStore();
+    await store.set('k', { source: 'idb' });
+    localStorage.setItem('k', JSON.stringify({ source: 'stale localStorage' }));
+    expect(await store.get('k')).toEqual({ source: 'idb' });
+  });
+
+  it('removes both copies on delete', async () => {
+    const store = freshStore();
+    await store.set('k', { a: 1 });
+    localStorage.setItem('k', JSON.stringify({ a: 1 }));
+    await store.del('k');
+    expect(await store.get('k')).toBeUndefined();
+    expect(localStorage.getItem('k')).toBeNull();
+  });
+});

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -41,7 +41,15 @@ export const formatBytes = (bytes) => {
 };
 
 /**
- * Bytes IndexedDB is using, or null where the browser will not break it out.
+ * Bytes IndexedDB is using ACROSS THE WHOLE ORIGIN, or null where the browser
+ * will not break it out.
+ *
+ * This is every database dayGLANCE has, not any one of them: auto-backups, the
+ * DB root key store, the intents outbox, the sync snapshot and the Todoist
+ * cache. On a real install auto-backups dominates it. There is no API for
+ * per-database sizes — `indexedDB.databases()` lists names only — so callers
+ * must describe this as total database usage and never attribute it to one
+ * feature.
  *
  * `navigator.storage.estimate()` reports usage across ALL storage buckets, and
  * for dayGLANCE that total is dominated by the service worker precache: roughly


### PR DESCRIPTION
Refs #1627. Two pieces of fallout from verifying the storage migration on a real install.

---

# 1. The IndexedDB path had never executed

jsdom ships no IndexedDB, and there was no `fake-indexeddb` in devDependencies, so **every existing test ran `createIdbKeyValue`'s localStorage fallback**. Opening the database, creating the object store on upgrade, and the transaction and request plumbing had zero executions anywhere, CI included, while #1629, #1630 and #1631 came to depend on them.

The fallback made this worse rather than better. Had IndexedDB failed to open in production, everything would have kept working against localStorage and nothing would have looked wrong: no benefit, no error, no signal.

## Why one file rather than a global setup

`fake-indexeddb/auto` is imported by the new test file only, because vitest isolates each file's environment by default. Installing it globally would have quietly stopped `idbKeyValue.test.js`, the Todoist hook tests and `dbEngineWiring.test.js` from testing the fallback they exist to cover. Both paths now have a home:

| file | covers |
|---|---|
| `idbKeyValue.test.js` | the localStorage fallback, where IndexedDB will not open |
| `idbKeyValue.idb.test.js` | the real IndexedDB path |

## What it covers

Store creation and round-trip (which is what proves `onupgradeneeded` ran, since a missing store would throw and silently fall back), structured clones rather than a JSON round trip, missing keys, overwrite, delete, independence across keys and across databases, and connection reuse.

Then the four migration behaviours the whole relocation rests on: reading a value an older version left in localStorage, clearing that copy once it is rewritten so the bytes are actually reclaimed, preferring IndexedDB over a stale copy, and removing both on delete.

---

# 2. The database line was mislabelled

The line I added in #1631 read **"Sync caches: 5.6 MB"**. The same production check showed that is wrong twice over.

`usageDetails.indexedDB` reports **every** IndexedDB database the origin has, not one of them: auto-backups, the DB root key store, the intents outbox, the sync snapshot and the Todoist cache. On a real install `dayglance-auto-backups` dominates the figure, so naming it after sync caches attributes almost all of it to the wrong feature.

It also read as alarming. 5.6 MB sitting under a meter reading 1.5 MB of ~5 MB invites the conclusion that something is oversized, when it is backups doing exactly their job in the tier built for them.

Now: **"Databases: {{used}}, stored separately with a much larger limit."** That claims only what the API measures, and frames the number as headroom rather than pressure.

A per-database breakdown isn't available to fix it more precisely: `indexedDB.databases()` lists names without sizes. The doc comment on `getIndexedDbUsage` now says so, so nobody tries to re-attribute the figure later.

---

## Verified in production first

A real install went from **3.0 MB to 1.50 MB** of localStorage, with `dayglance-vault-db-sync-snapshot` gone and the new databases present. So the tests here pin behaviour already known to work, rather than asserting it for the first time.

## Validation

- Full suite: 3,760 passing, up from 3,748, with the fallback suites confirmed still passing (isolation holds)
- `eslint src/` clean
- Label change covers all eight locale bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8k44pwgABpWA4bzd7RPm5