### PR TITLE
Month view step 4: day sheet rendered by SCHED scoped to one date

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -549,6 +549,10 @@ const DayPlanner = () => {
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [deadlinePickerTaskId, setDeadlinePickerTaskId] = useState(null); // Task ID for deadline date picker
   const [showMonthView, setShowMonthView] = useState(false);
+  // The month view's displayed grid range ({ from, to }, YYYY-MM-DD) while it
+  // is showing, so recurring occurrences are expanded for every cell it
+  // draws and for the day sheet opened from one; null when it is not showing.
+  const [monthViewRange, setMonthViewRange] = useState(null);
   // Ambient Day Dial overlay ('O'). `?dial` boots straight into it — the
   // kiosk/wall-panel entry, same idiom as the tray popup's `?tray` (a plain
   // URL beats per-platform launch flags: it works for a Docker kiosk browser,
@@ -6372,6 +6376,7 @@ const DayPlanner = () => {
     // forward off a weekend-only recurring task's day.
     const allDateStrs = [...visibleDates.map(d => dateToString(d)),
       ...weekViewDates.map(d => dateToString(d)),
+      ...(monthViewRange ? [monthViewRange.from, monthViewRange.to] : []),
       dateToString(selectedDate), dateToString(schedWindowEnd), today].sort();
     const rangeStart = allDateStrs[0];
     const rangeEnd = allDateStrs[allDateStrs.length - 1];
@@ -6412,7 +6417,7 @@ const DayPlanner = () => {
       }
     }
     return instances;
-  }, [recurringTasks, visibleDates, weekViewDates, selectedDate, schedDaysShown]);
+  }, [monthViewRange, recurringTasks, visibleDates, weekViewDates, selectedDate, schedDaysShown]);
   expandedRecurringTasksRef.current = expandedRecurringTasks;
 
   // Build today's non-overdue HG sessions for the reminder engine.
@@ -8436,6 +8441,7 @@ const DayPlanner = () => {
     mobileWelcomeStep, setMobileWelcomeStep,
     desktopWelcomeStep, setDesktopWelcomeStep,
     showMonthView, setShowMonthView,
+    monthViewRange, setMonthViewRange,
     showDayDial, setShowDayDial,
     viewedMonth, setViewedMonth,
     mobileReviewPage, setMobileReviewPage,

--- a/src/components/month/MonthDaySheet.jsx
+++ b/src/components/month/MonthDaySheet.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
+import SchedView from '../sched/SchedView.jsx';
+import useSheetDismissal from '../../hooks/useSheetDismissal.js';
+import { formatLocalizedDate } from '../../utils/localeFormatting.js';
+
+// Month view day sheet (step 4). Tapping a cell opens this: the day's agenda
+// rendered by SCHED scoped to that one date, so the cards, completion
+// toggles and edit affordances are exactly the ones people already know.
+// A bottom sheet at ~88% of the height on every platform (a sheet, not a
+// popup anchored to the cell), with the content scrolling inside it.
+//
+// Dismissal: Escape; browser and Android back through a pushed history
+// entry (the Android WebView pops it with goBack()); pull-down from the top
+// of the content and a drag on the handle; a left-edge swipe for iOS, which
+// has no free back gesture; the backdrop; and the close button. All of it
+// is one controller (utils/sheetDismissal.js) so each path closes once.
+//
+// Stacking: z-[46], above the month overlay and the tab bar (40), below the
+// filter popup and the task editors (50, 80) that open from inside it.
+
+export const MONTH_DAY_SHEET_HISTORY_KEY = 'monthDaySheet';
+
+/**
+ * @param {object} props
+ * @param {string} props.date       YYYY-MM-DD; the sheet shows this one day
+ * @param {() => void} props.onClose
+ */
+export default function MonthDaySheet({ date, onClose }) {
+  const { cardBg, borderClass, textPrimary, textSecondary, hoverBg } = useDayPlannerCtx();
+  const { t, i18n } = useTranslation();
+  const scrollRef = useRef(null);
+  const [entered, setEntered] = useState(false);
+  useEffect(() => { const id = requestAnimationFrame(() => setEntered(true)); return () => cancelAnimationFrame(id); }, []);
+
+  const { dismiss, dragOffset, dragging, handleProps, contentProps } = useSheetDismissal({
+    open: !!date, key: MONTH_DAY_SHEET_HISTORY_KEY, onClose, scrollRef,
+  });
+  if (!date) return null;
+
+  const language = i18n.resolvedLanguage || i18n.language || 'en';
+  const title = formatLocalizedDate(new Date(`${date}T12:00:00`), { weekday: 'long', month: 'long', day: 'numeric' }, language);
+
+  return (
+    <div data-month-day-sheet={date} className="fixed inset-0 z-[46] flex flex-col justify-end" role="presentation">
+      <div data-month-day-sheet-backdrop className="absolute inset-0 bg-black/40" onClick={dismiss} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className={`relative w-full sm:max-w-2xl sm:mx-auto ${cardBg} ${textPrimary} rounded-t-2xl shadow-xl flex flex-col
+          h-[88vh] ${dragging ? '' : 'transition-transform duration-200 ease-out'}`}
+        style={{
+          transform: `translateY(${entered ? dragOffset : 2000}px)`,
+          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+        }}
+      >
+        <div data-month-day-sheet-handle {...handleProps} className={`shrink-0 flex items-center gap-2 px-3 pt-2 pb-1 border-b ${borderClass} cursor-grab active:cursor-grabbing select-none`}>
+          <div className="absolute left-1/2 -translate-x-1/2 top-1.5 w-10 h-1 rounded-full bg-stone-300 dark:bg-gray-600" aria-hidden="true" />
+          <span className="text-sm font-semibold pt-2 truncate">{title}</span>
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label={t('common.close')}
+            className={`ml-auto mt-1 p-1.5 rounded-lg ${textSecondary} ${hoverBg}`}
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div ref={scrollRef} {...contentProps} data-month-day-sheet-content className="flex-1 min-h-0 overflow-y-auto overscroll-contain">
+          <SchedView dateRange={{ from: date, to: date }} embedded />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/month/MonthDaySheet.test.jsx
+++ b/src/components/month/MonthDaySheet.test.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import i18next from 'i18next';
+import { I18nextProvider } from 'react-i18next';
+import { DayPlannerContext } from '../../context/DayPlannerContext.jsx';
+import { FeaturesContext } from '../../context/FeaturesContext.jsx';
+import { SyncContext } from '../../context/SyncContext.jsx';
+import { loaders } from '../../locales.js';
+import MonthDaySheet from './MonthDaySheet.jsx';
+
+// useSchedAgendaState reads view preferences from localStorage in its state
+// initialisers; there is no DOM here, so give it an empty store.
+if (typeof globalThis.localStorage === 'undefined') {
+  globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+}
+
+// Static markup (no jsdom): what the sheet renders for a date. The dismissal
+// paths are the controller's and are covered in utils/sheetDismissal.test.js.
+
+async function i18nFor(language) {
+  const bundle = await loaders[language]();
+  const i18n = i18next.createInstance();
+  await i18n.init({ lng: language, fallbackLng: false, resources: { [language]: { translation: bundle } }, interpolation: { escapeValue: false } });
+  return i18n;
+}
+const dateToStr = (d) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+const byDate = {
+  '2026-09-16': [{ id: 't16', title: 'Deep work on the sixteenth', date: '2026-09-16', startTime: '09:00', duration: 60, color: 'bg-blue-500' }],
+  '2026-09-17': [{ id: 't17', title: 'Only on the seventeenth', date: '2026-09-17', startTime: '09:00', duration: 60, color: 'bg-red-500' }],
+};
+const planner = {
+  darkMode: false, cardBg: 'bg-white', borderClass: 'border-stone-300', textPrimary: 'text-stone-900', textSecondary: 'text-stone-600', hoverBg: 'hover:bg-stone-100',
+  selectedDate: new Date('2026-09-12T12:00:00'), schedDaysShown: 14, setSchedDaysShown: () => {},
+  tasks: Object.values(byDate).flat(), unscheduledTasks: [], expandedRecurringTasks: [], currentTime: new Date('2026-09-12T12:00:00'),
+  getTasksForDate: (date) => byDate[dateToStr(date)] || [],
+  getDeadlineTasksForDate: () => [],
+  formatTime: (t) => t, use24HourClock: true, isTablet: false,
+  setNewTask: () => {}, setShowAddTask: () => {}, scheduleTaskAtNextSlot: () => {},
+  toggleComplete: () => {}, openMobileEditTask: () => {}, postponeTask: () => {},
+  updateTaskNotes: () => {}, addSubtask: () => {}, toggleSubtask: () => {}, deleteSubtask: () => {}, updateSubtaskTitle: () => {},
+  calendarRef: { current: null },
+};
+const features = { isVisibleForUser: () => true, routinesEnabled: false, todayRoutines: [], routineCompletions: {}, projects: [], goals: [], goalsProjectsEnabled: false, aiConfig: { features: {} } };
+const render = (i18n, date) => renderToStaticMarkup(
+  <I18nextProvider i18n={i18n}>
+    <DayPlannerContext.Provider value={planner}><FeaturesContext.Provider value={features}><SyncContext.Provider value={{}}>
+      <MonthDaySheet date={date} onClose={() => {}} />
+    </SyncContext.Provider></FeaturesContext.Provider></DayPlannerContext.Provider>
+  </I18nextProvider>,
+);
+
+describe('MonthDaySheet', () => {
+  it('opens as a dialog for the date and renders SCHED scoped to that one day', async () => {
+    const html = render(await i18nFor('en'), '2026-09-16');
+    expect(html).toContain('data-month-day-sheet="2026-09-16"');
+    expect(html).toMatch(/role="dialog" aria-modal="true" aria-label="Wednesday, September 16"/);
+    expect(html).toContain('data-sched-view="scoped"');
+    expect(html).toContain('Deep work on the sixteenth');
+    expect(html).not.toContain('Only on the seventeenth');
+    expect(html).not.toContain('Show 14 more days');
+    expect(html).not.toContain('Empty days');
+  });
+
+  it('shows an empty day rather than nothing', async () => {
+    const html = render(await i18nFor('en'), '2026-09-20');
+    expect(html).toContain('data-sched-view="scoped"');
+    expect(html).toContain('Add task');
+    expect(html).not.toContain('Nothing scheduled in this window');
+  });
+
+  it('carries the dismissal affordances: handle, close button, backdrop', async () => {
+    const html = render(await i18nFor('en'), '2026-09-16');
+    expect(html).toContain('data-month-day-sheet-handle');
+    expect(html).toContain('aria-label="Close"');
+    expect(html).toContain('data-month-day-sheet-backdrop');
+    expect(html).toContain('data-month-day-sheet-content');
+    expect(html).toContain('h-[88vh]');
+  });
+
+  it('renders nothing without a date', async () => {
+    expect(render(await i18nFor('en'), null)).toBe('');
+  });
+
+  it('localizes the title', async () => {
+    const de = render(await i18nFor('de'), '2026-09-16');
+    expect(de).toContain('aria-label="Mittwoch, 16. September"');
+    expect(de).toContain('aria-label="Schließen"');
+  });
+});

--- a/src/components/month/MonthGridDevOverlay.jsx
+++ b/src/components/month/MonthGridDevOverlay.jsx
@@ -8,12 +8,13 @@
 // │ Delete this file and the gate in src/App.jsx once the grid is routed     │
 // │ through the view cycler.                                                 │
 // └──────────────────────────────────────────────────────────────────────────┘
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { X } from 'lucide-react';
 import { routinesForDate } from '@glance-apps/agenda-core';
 import MonthGrid from './MonthGrid.jsx';
+import MonthDaySheet from './MonthDaySheet.jsx';
 import { tagKind } from '../../utils/monthCellLayout.js';
-import { monthOf } from '../../utils/monthGrid.js';
+import { monthGridDates, monthOf } from '../../utils/monthGrid.js';
 import { generateDemoMonth } from '../../utils/monthDemoData.js';
 import { useDayPlannerCtx } from '../../context/DayPlannerContext.jsx';
 import { useFeaturesCtx } from '../../context/FeaturesContext.jsx';
@@ -57,7 +58,7 @@ function useDemoItemsForDate(year, month) {
 }
 
 export default function MonthGridDevOverlay() {
-  const { bgClass, textPrimary, textSecondary, weekStartDay, selectedDate } = useDayPlannerCtx();
+  const { bgClass, textPrimary, textSecondary, weekStartDay, selectedDate, setMonthViewRange } = useDayPlannerCtx();
   // On macOS Electron (titleBarStyle hiddenInset) the top 28px is still the
   // window's title bar: transparent, but clicks there never reach the page.
   // DesktopLayout pads its chrome by the same amount (titlebarH).
@@ -77,13 +78,21 @@ export default function MonthGridDevOverlay() {
   const demoItemsForDate = useDemoItemsForDate(shown.year, shown.month);
   const itemsForDate = demo ? demoItemsForDate : realItemsForDate;
   const [hidden, setHidden] = useState(false);
+  const [sheetDate, setSheetDate] = useState(null);
+  // Recurring occurrences are expanded for the grid's whole range while it shows.
+  useEffect(() => {
+    if (hidden || !setMonthViewRange) return undefined;
+    const { cells } = monthGridDates(shown.year, shown.month, weekStartDay);
+    setMonthViewRange({ from: cells[0].dateStr, to: cells[cells.length - 1].dateStr });
+    return () => setMonthViewRange(null);
+  }, [hidden, shown.year, shown.month, weekStartDay, setMonthViewRange]);
   if (hidden) return null;
   return (
-    <div className={`fixed inset-0 z-[80] flex flex-col ${bgClass} ${textPrimary}`}
+    <div className={`fixed inset-0 z-[45] flex flex-col ${bgClass} ${textPrimary}`}
       style={{ paddingTop: `calc(env(safe-area-inset-top, 0px) + ${titlebarH}px)`, paddingBottom: 'env(safe-area-inset-bottom)' }}>
       <div className={`flex items-center gap-3 px-3 py-1 text-[11px] ${textSecondary} shrink-0`}>
         <span className="font-semibold">Month grid (TEMPORARY dev overlay, real data)</span>
-        <span className="hidden sm:inline">tap a cell: logs the date until the day sheet exists</span>
+        <span className="hidden sm:inline">tap a cell to open its day sheet</span>
         <span data-month-grid-source={demo ? 'demo' : 'real'} className={demo ? 'font-semibold text-amber-700 dark:text-amber-300' : ''}>
           {demo ? 'showing: generated demo month' : 'showing: your data'}
         </span>
@@ -102,9 +111,10 @@ export default function MonthGridDevOverlay() {
           itemsForDate={itemsForDate}
           weekStartDay={weekStartDay}
           onNavigate={(year, month) => setShown({ year, month })}
-          onSelectDate={(dateStr) => console.log('[month-grid] select', dateStr)}
+          onSelectDate={setSheetDate}
         />
       </div>
+      {sheetDate && <MonthDaySheet date={sheetDate} onClose={() => setSheetDate(null)} />}
     </div>
   );
 }

--- a/src/components/sched/SchedView.jsx
+++ b/src/components/sched/SchedView.jsx
@@ -12,8 +12,14 @@ import { SchedDeadlineCard, SchedRoutinePills } from './SchedDayExtras.jsx';
  * SCHED — scrollable day-grouped agenda of scheduled tasks, starting at the
  * currently selected day. Third mobile/tablet view alongside GRID and LIST;
  * the desktop dashboard (SchedDashboard) shares the same agenda state.
+ *
+ * With `dateRange` ({ from, to }, YYYY-MM-DD) the agenda is scoped to those
+ * days: the month view's day sheet, which renders this same view for one
+ * date so the cards, toggles and edit affordances are the ones people know.
+ * `embedded` says the view is inside a sheet rather than the calendar area:
+ * it leaves the calendar's scroll alone and drops the window controls.
  */
-const SchedView = () => {
+const SchedView = ({ dateRange, embedded = false } = {}) => {
   const { borderClass, textSecondary, hoverBg, calendarRef } = useDayPlannerCtx();
   const { t } = useTranslation();
   const [showFilters, setShowFilters] = useState(false);
@@ -21,7 +27,7 @@ const SchedView = () => {
   // The shared scroll container keeps GRID/LIST's scroll offset (e.g. the
   // timeline's scroll-to-now); SCHED starts at the top of the agenda.
   useEffect(() => {
-    calendarRef?.current?.scrollTo?.({ top: 0 });
+    if (!embedded) calendarRef?.current?.scrollTo?.({ top: 0 });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -37,7 +43,8 @@ const SchedView = () => {
     hidePastEvents, toggleHidePastEvents,
     showMoreDays,
     addTaskOnDay,
-  } = useSchedAgendaState();
+    scoped,
+  } = useSchedAgendaState({ dateRange });
 
   const todayStr = dateToString(new Date());
   const tomorrowStr = dateToString(new Date(Date.now() + 86400000));
@@ -50,7 +57,7 @@ const SchedView = () => {
   };
 
   return (
-    <div className="flex flex-col gap-3 px-3 pb-24 pt-2">
+    <div data-sched-view={scoped ? 'scoped' : 'rolling'} className={`flex flex-col gap-3 px-3 ${embedded ? 'pb-6' : 'pb-24'} pt-2`}>
       {/* Controls */}
       <div className="flex items-center gap-2">
         <button
@@ -64,14 +71,16 @@ const SchedView = () => {
           <ListFilter size={13} />
           {t('sched.filter', 'Filter')}{filtersActive ? ` · ${filters.colors.length + filters.tags.length + filters.projectIds.length}` : ''}
         </button>
-        <button
-          onClick={toggleEmptyDays}
-          className={`flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded-lg border ${borderClass} ${textSecondary} ${hoverBg} transition-colors`}
-          title={showEmptyDays ? t('sched.hideEmptyDays', 'Hide empty days') : t('sched.showEmptyDays', 'Show empty days')}
-        >
-          {showEmptyDays ? <Eye size={13} /> : <EyeOff size={13} />}
-          {t('sched.emptyDays', 'Empty days')}
-        </button>
+        {!scoped && (
+          <button
+            onClick={toggleEmptyDays}
+            className={`flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded-lg border ${borderClass} ${textSecondary} ${hoverBg} transition-colors`}
+            title={showEmptyDays ? t('sched.hideEmptyDays', 'Hide empty days') : t('sched.showEmptyDays', 'Show empty days')}
+          >
+            {showEmptyDays ? <Eye size={13} /> : <EyeOff size={13} />}
+            {t('sched.emptyDays', 'Empty days')}
+          </button>
+        )}
       </div>
 
       {/* Overdue — incomplete tasks from before the visible window */}
@@ -116,14 +125,16 @@ const SchedView = () => {
         </p>
       )}
 
-      {/* Extend window */}
-      <button
-        onClick={showMoreDays}
-        className={`flex items-center justify-center gap-1.5 py-2.5 text-xs font-medium ${textSecondary} ${hoverBg} rounded-xl border ${borderClass} transition-colors`}
-      >
-        <ChevronDown size={13} />
-        {t('sched.showMoreDays', 'Show {{days}} more days', { days: LOAD_MORE_DAYS })}
-      </button>
+      {/* Extend window (the rolling agenda only; a scoped range is what it is) */}
+      {!scoped && (
+        <button
+          onClick={showMoreDays}
+          className={`flex items-center justify-center gap-1.5 py-2.5 text-xs font-medium ${textSecondary} ${hoverBg} rounded-xl border ${borderClass} transition-colors`}
+        >
+          <ChevronDown size={13} />
+          {t('sched.showMoreDays', 'Show {{days}} more days', { days: LOAD_MORE_DAYS })}
+        </button>
+      )}
 
       {showFilters && (
         <SchedFilterPopup

--- a/src/components/sched/useSchedAgendaState.js
+++ b/src/components/sched/useSchedAgendaState.js
@@ -14,8 +14,18 @@ const PRESETS_KEY = 'day-planner-sched-filter-presets';
  * SchedDashboard): the rolling day window anchored on selectedDate,
  * filter state, filter options derived from the visible window, the
  * empty-days preference, and the add-task-on-day helper.
+ *
+ * @param {{ dateRange?: { from: string, to: string } }} [options]
+ *   dateRange (YYYY-MM-DD, inclusive) scopes the agenda to exactly those
+ *   days instead of the rolling window: the month view's day sheet. A
+ *   scoped agenda always shows its days (even empty ones), has no overdue
+ *   section and no "show more days". Callers that pass nothing get the
+ *   rolling window exactly as before.
  */
-export default function useSchedAgendaState() {
+export default function useSchedAgendaState({ dateRange } = {}) {
+  const scoped = !!(dateRange && dateRange.from && dateRange.to);
+  const scopeFrom = scoped ? dateRange.from : null;
+  const scopeTo = scoped ? dateRange.to : null;
   const {
     selectedDate, tasks, unscheduledTasks, expandedRecurringTasks,
     getTasksForDate, getDeadlineTasksForDate,
@@ -103,12 +113,26 @@ export default function useSchedAgendaState() {
 
   const showMoreDays = () => setDaysShown(n => n + LOAD_MORE_DAYS);
 
-  // Unfiltered agenda window (day → tasks), all-day first then by start time.
-  const rawDays = useMemo(() => {
+  // The dates the agenda covers: the scoped range, or the rolling window.
+  const windowDates = useMemo(() => {
     const out = [];
+    if (scoped) {
+      const end = new Date(`${scopeTo}T12:00:00`);
+      for (const d = new Date(`${scopeFrom}T12:00:00`); d <= end && out.length < 366; d.setDate(d.getDate() + 1)) out.push(new Date(d));
+      return out;
+    }
     for (let i = 0; i < daysShown; i++) {
       const date = new Date(selectedDate);
       date.setDate(date.getDate() + i);
+      out.push(date);
+    }
+    return out;
+  }, [scoped, scopeFrom, scopeTo, selectedDate, daysShown]);
+
+  // Unfiltered agenda window (day → tasks), all-day first then by start time.
+  const rawDays = useMemo(() => {
+    const out = [];
+    for (const date of windowDates) {
       // Second arg opts out of the app-wide tag filter — SCHED has its own
       // filter panel, and the invisible global filter made freshly-tagged
       // tasks vanish from the agenda.
@@ -125,7 +149,7 @@ export default function useSchedAgendaState() {
     // getTasksForDate reads tasks + expandedRecurringTasks internally;
     // getDeadlineTasksForDate reads unscheduledTasks.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedDate, daysShown, tasks, unscheduledTasks, expandedRecurringTasks]);
+  }, [windowDates, tasks, unscheduledTasks, expandedRecurringTasks]);
 
   // Filter options offered in the UI come from the visible window.
   const { availableColors, availableTags } = useMemo(() => {
@@ -157,7 +181,7 @@ export default function useSchedAgendaState() {
   const todayHasRoutines = routinesEnabled && todayRoutines.length > 0;
   const agendaTodayStr = dateToString(new Date());
   const visibleDays = days.filter(d =>
-    showEmptyDays || d.tasks.length > 0 || d.deadlineTasks.length > 0 ||
+    scoped || showEmptyDays || d.tasks.length > 0 || d.deadlineTasks.length > 0 ||
     (d.dateStr === agendaTodayStr && todayHasRoutines));
 
   // Incomplete tasks scheduled before today AND before the visible window, so
@@ -165,6 +189,7 @@ export default function useSchedAgendaState() {
   // events just passed (nothing actionable), and recurring occurrences are
   // generated per-day rather than lingering in the tasks list.
   const overdueTasks = useMemo(() => {
+    if (scoped) return [];
     const todayStr = dateToString(new Date());
     const windowStartStr = dateToString(selectedDate);
     return tasks
@@ -174,7 +199,7 @@ export default function useSchedAgendaState() {
         isVisibleForUser(task))
       .filter(task => taskMatchesSchedFilters(task, filters))
       .sort((a, b) => a.date.localeCompare(b.date) || (a.startTime || '').localeCompare(b.startTime || ''));
-  }, [tasks, selectedDate, filters, isVisibleForUser]);
+  }, [scoped, tasks, selectedDate, filters, isVisibleForUser]);
 
   // Moves an overdue/agenda task to today's next open quarter-hour slot.
   const rescheduleToToday = (task) => scheduleTaskAtNextSlot(task.id, false);
@@ -185,6 +210,7 @@ export default function useSchedAgendaState() {
   };
 
   return {
+    scoped,
     days, visibleDays, filtersActive,
     overdueTasks, rescheduleToToday,
     filters, setFilters,

--- a/src/components/sched/useSchedAgendaState.scope.test.jsx
+++ b/src/components/sched/useSchedAgendaState.scope.test.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DayPlannerContext } from '../../context/DayPlannerContext.jsx';
+import { FeaturesContext } from '../../context/FeaturesContext.jsx';
+import useSchedAgendaState from './useSchedAgendaState.js';
+
+// useSchedAgendaState reads view preferences from localStorage in its state
+// initialisers; there is no DOM here, so give it an empty store.
+if (typeof globalThis.localStorage === 'undefined') {
+  globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+}
+
+// The optional dateRange must scope the agenda to exactly those days and
+// leave the rolling window (the existing SCHED call path) untouched.
+
+const dateToStr = (d) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+const byDate = {
+  '2026-09-10': [{ id: 'a', title: 'A', date: '2026-09-10', startTime: '09:00', duration: 30 }],
+  '2026-09-16': [{ id: 'b', title: 'B', date: '2026-09-16', startTime: '10:00', duration: 30 }, { id: 'c', title: 'C', date: '2026-09-16', isAllDay: true }],
+  '2026-09-30': [{ id: 'd', title: 'D', date: '2026-09-30', startTime: '12:00', duration: 30 }],
+};
+const planner = {
+  selectedDate: new Date('2026-09-12T12:00:00'), schedDaysShown: 14, setSchedDaysShown: () => {},
+  tasks: [{ id: 'old', title: 'Overdue', date: '2026-09-01', completed: false }, ...Object.values(byDate).flat()],
+  unscheduledTasks: [], expandedRecurringTasks: [], currentTime: new Date('2026-09-12T12:00:00'),
+  getTasksForDate: (date) => byDate[dateToStr(date)] || [],
+  getDeadlineTasksForDate: (dateStr) => (dateStr === '2026-09-16' ? [{ id: 'dl', title: 'Due', deadline: dateStr }] : []),
+  setNewTask: () => {}, setShowAddTask: () => {}, scheduleTaskAtNextSlot: () => {},
+};
+const features = { isVisibleForUser: () => true, routinesEnabled: false, todayRoutines: [] };
+
+const Probe = ({ options }) => {
+  const s = useSchedAgendaState(options);
+  return <pre>{JSON.stringify({ scoped: s.scoped, days: s.visibleDays.map((d) => `${d.dateStr}:${d.tasks.map((t) => t.id).join('')}:${d.deadlineTasks.map((t) => t.id).join('')}`), overdue: s.overdueTasks.map((t) => t.id) })}</pre>;
+};
+const probe = (options) => JSON.parse(renderToStaticMarkup(
+  <DayPlannerContext.Provider value={planner}><FeaturesContext.Provider value={features}><Probe options={options} /></FeaturesContext.Provider></DayPlannerContext.Provider>,
+).replace(/<[^>]+>/g, '').replace(/&quot;/g, '"'));
+
+describe('useSchedAgendaState dateRange', () => {
+  it('leaves the rolling window untouched when no options are passed', () => {
+    const out = probe(undefined);
+    expect(out.scoped).toBe(false);
+    // 14 days from the 12th, empty days hidden: only the days with items.
+    expect(out.days).toEqual(['2026-09-16:cb:dl']);
+    // Both the 1st and the 10th fall before the window (and before today).
+    expect(out.overdue).toEqual(['old', 'a']);
+  });
+
+  it('scopes to exactly one date, shows it even when empty, and drops the overdue section', () => {
+    expect(probe({ dateRange: { from: '2026-09-16', to: '2026-09-16' } })).toEqual({ scoped: true, days: ['2026-09-16:cb:dl'], overdue: [] });
+    expect(probe({ dateRange: { from: '2026-09-30', to: '2026-09-30' } })).toEqual({ scoped: true, days: ['2026-09-30:d:'], overdue: [] });
+    expect(probe({ dateRange: { from: '2026-09-20', to: '2026-09-20' } })).toEqual({ scoped: true, days: ['2026-09-20::'], overdue: [] });
+  });
+
+  it('covers a multi-day range inclusively, in order', () => {
+    const out = probe({ dateRange: { from: '2026-09-09', to: '2026-09-11' } });
+    expect(out.days).toEqual(['2026-09-09::', '2026-09-10:a:', '2026-09-11::']);
+  });
+
+  it('treats an incomplete range as no range', () => {
+    expect(probe({ dateRange: { from: '2026-09-16' } }).scoped).toBe(false);
+  });
+});

--- a/src/hooks/useSheetDismissal.js
+++ b/src/hooks/useSheetDismissal.js
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createSheetController } from '../utils/sheetDismissal.js';
+
+/**
+ * Dismissal for a near-full-height sheet: Escape, browser/Android back
+ * (via a pushed history entry), pull-down from the top of the content, a
+ * drag on the handle, and a left-edge swipe. The decisions live in
+ * utils/sheetDismissal.js; this only connects them to the DOM.
+ *
+ * @param {{ open: boolean, key: string, onClose: (reason: string) => void, scrollRef: React.RefObject }} args
+ * @returns {{ dismiss: () => void, dragOffset: number, dragging: boolean,
+ *   handleProps: object, contentProps: object }}
+ *   handleProps go on the drag handle/header (mouse and touch, touch-action: none);
+ *   contentProps go on the scrolling body (touch only, pull-down from scrollTop 0).
+ */
+export default function useSheetDismissal({ open, key, onClose, scrollRef }) {
+  const ctlRef = useRef(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const [dragOffset, setDragOffset] = useState(0);
+  const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    if (!open || typeof window === 'undefined') return undefined;
+    const ctl = createSheetController({
+      key,
+      onClose: (reason) => onCloseRef.current?.(reason),
+      win: {
+        history: window.history,
+        addEventListener: (type, fn) => window.addEventListener(type, fn),
+        removeEventListener: (type, fn) => window.removeEventListener(type, fn),
+        // A card's notes panel owns Escape while it is open (see SchedTaskCard).
+        hasInnerOverlay: () => !!document.querySelector('.sched-notes-panel'),
+      },
+    });
+    ctl.open();
+    ctlRef.current = ctl;
+    return () => { ctl.dispose(); ctlRef.current = null; };
+  }, [open, key]);
+
+  const dismiss = useCallback(() => ctlRef.current?.dismiss('button'), []);
+
+  const start = useCallback((x, y, fromContent) => {
+    const scrollTop = fromContent ? (scrollRef?.current?.scrollTop || 0) : 0;
+    ctlRef.current?.onDragStart({ x, y, t: performance.now(), scrollTop });
+    setDragging(true);
+  }, [scrollRef]);
+  const move = useCallback((x, y) => {
+    const offset = ctlRef.current?.onDragMove({ x, y, t: performance.now() }) || 0;
+    setDragOffset(offset);
+  }, []);
+  const end = useCallback(() => {
+    const dismissed = ctlRef.current?.onDragEnd();
+    setDragging(false);
+    if (!dismissed) setDragOffset(0);
+  }, []);
+
+  // Handle: pointer events so a mouse drag works too; touch-action none so
+  // the browser never turns the gesture into a scroll. The pointer is only
+  // captured once it has moved: capturing on pointerdown retargets the
+  // click to the handle row, which would make the close button dead.
+  const handleProps = {
+    style: { touchAction: 'none' },
+    onPointerDown: (e) => { start(e.clientX, e.clientY, false); },
+    onPointerMove: (e) => {
+      if (!ctlRef.current?.isDragging()) return;
+      if (!e.currentTarget.hasPointerCapture?.(e.pointerId)) e.currentTarget.setPointerCapture?.(e.pointerId);
+      move(e.clientX, e.clientY);
+    },
+    onPointerUp: end,
+    onPointerCancel: end,
+  };
+  // Content: touch only, passive, so scrolling stays native; the pull-down
+  // only translates the sheet once the content is at its top.
+  const contentProps = {
+    onTouchStart: (e) => { const t = e.touches[0]; start(t.clientX, t.clientY, true); },
+    onTouchMove: (e) => { const t = e.touches[0]; move(t.clientX, t.clientY); },
+    onTouchEnd: end,
+    onTouchCancel: end,
+  };
+
+  return { dismiss, dragOffset, dragging, handleProps, contentProps };
+}

--- a/src/utils/sheetDismissal.js
+++ b/src/utils/sheetDismissal.js
@@ -1,0 +1,100 @@
+// Dismissal rules for a near-full-height sheet, as pure decisions plus a
+// small controller that a hook wires to the DOM. Pure so every path can be
+// tested without a browser: Escape, the browser or Android back (a pushed
+// history entry the WebView's goBack() pops), pull-down on the sheet, a
+// mouse drag on the handle, and the left-edge swipe iOS has no free gesture
+// for.
+
+export const SHEET_PULL_DISMISS_PX = 120;      // pull this far and letting go closes
+export const SHEET_FLING_VELOCITY = 0.6;       // px per ms: a quick short flick also closes
+export const SHEET_EDGE_START_PX = 24;         // a swipe that begins this close to the left edge
+export const SHEET_EDGE_DISMISS_PX = 80;       // and travels this far right closes
+
+/** A pull-down closes only from the top of the content, so scrolling never dismisses by accident. */
+export function shouldDismissPull({ dy, dtMs, scrollTop }) {
+  if (!(dy > 0) || scrollTop > 0) return false;
+  if (dy >= SHEET_PULL_DISMISS_PX) return true;
+  return dtMs > 0 && dy / dtMs >= SHEET_FLING_VELOCITY && dy >= 24;
+}
+
+/** A left-edge swipe: starts at the edge, moves right, and stays more horizontal than vertical. */
+export function shouldDismissEdgeSwipe({ startX, dx, dy }) {
+  return startX <= SHEET_EDGE_START_PX && dx >= SHEET_EDGE_DISMISS_PX && Math.abs(dy) < dx;
+}
+
+/**
+ * @param {object} deps
+ * @param {string} deps.key      history-state key that marks this sheet's entry
+ * @param {(reason: string) => void} deps.onClose
+ * @param {object} deps.win      window-like: { history, addEventListener, removeEventListener, hasNotesPanel? }
+ */
+export function createSheetController({ key, onClose, win }) {
+  let opened = false;
+  let closed = false;
+  let drag = null;
+
+  const close = (reason) => {
+    if (closed) return;
+    closed = true;
+    onClose(reason);
+  };
+
+  const ownsHistoryEntry = () => !!win.history?.state?.[key];
+
+  // Every non-back path leaves through history when we pushed an entry, so
+  // the entry never lingers and a later back press cannot re-close a sheet
+  // that is already gone. popstate then does the actual close.
+  const dismiss = (reason) => {
+    if (closed) return;
+    if (ownsHistoryEntry()) { win.history.back(); return; }
+    close(reason);
+  };
+
+  const onPopState = () => close('back');
+  const onKeyDown = (event) => {
+    if (event.key !== 'Escape' || event.defaultPrevented) return;
+    // Inner overlays (a card's notes panel) handle their own Escape.
+    if (win.hasInnerOverlay?.()) return;
+    dismiss('escape');
+  };
+
+  const onDragStart = ({ x, y, t, scrollTop = 0 }) => {
+    drag = { x0: x, y0: y, t0: t, scrollTop, dx: 0, dy: 0, dt: 0 };
+  };
+  /** Returns the pull offset to translate the sheet by (0 while the content is scrolled). */
+  const onDragMove = ({ x, y, t }) => {
+    if (!drag) return 0;
+    drag.dx = x - drag.x0;
+    drag.dy = y - drag.y0;
+    drag.dt = t - drag.t0;
+    return drag.scrollTop === 0 && drag.dy > 0 && Math.abs(drag.dy) >= Math.abs(drag.dx) ? drag.dy : 0;
+  };
+  /** Returns true when the gesture dismissed the sheet. */
+  const onDragEnd = () => {
+    if (!drag) return false;
+    const { dx, dy, dt, scrollTop, x0 } = drag;
+    drag = null;
+    if (shouldDismissPull({ dy, dtMs: dt, scrollTop })) { dismiss('pull'); return true; }
+    if (shouldDismissEdgeSwipe({ startX: x0, dx, dy })) { dismiss('edge-swipe'); return true; }
+    return false;
+  };
+
+  const open = () => {
+    if (opened) return;
+    opened = true;
+    // Push one entry per sheet, not per controller: React StrictMode mounts
+    // an effect twice in development, and a second push would leave a stale
+    // entry that the next back press swallows instead of leaving the view.
+    if (win.history?.pushState && !ownsHistoryEntry()) {
+      win.history.pushState({ ...(win.history.state || {}), [key]: true }, '');
+    }
+    win.addEventListener('popstate', onPopState);
+    win.addEventListener('keydown', onKeyDown);
+  };
+  const dispose = () => {
+    win.removeEventListener('popstate', onPopState);
+    win.removeEventListener('keydown', onKeyDown);
+  };
+
+  return { open, dispose, dismiss, onKeyDown, onPopState, onDragStart, onDragMove, onDragEnd, isDragging: () => drag !== null };
+}

--- a/src/utils/sheetDismissal.test.js
+++ b/src/utils/sheetDismissal.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createSheetController, shouldDismissPull, shouldDismissEdgeSwipe,
+  SHEET_PULL_DISMISS_PX, SHEET_EDGE_DISMISS_PX, SHEET_EDGE_START_PX,
+} from './sheetDismissal.js';
+
+function fakeWindow({ hasInnerOverlay = false } = {}) {
+  const listeners = {};
+  const win = {
+    history: {
+      state: null,
+      entries: [],
+      pushState: vi.fn((state) => { win.history.entries.push(win.history.state); win.history.state = state; }),
+      back: vi.fn(() => { win.history.state = win.history.entries.pop() ?? null; (listeners.popstate || []).forEach((fn) => fn({ state: win.history.state })); }),
+    },
+    addEventListener: vi.fn((type, fn) => { (listeners[type] ||= []).push(fn); }),
+    removeEventListener: vi.fn((type, fn) => { listeners[type] = (listeners[type] || []).filter((f) => f !== fn); }),
+    hasInnerOverlay: () => hasInnerOverlay,
+    fire: (type, event) => (listeners[type] || []).forEach((fn) => fn(event)),
+    listenerCount: (type) => (listeners[type] || []).length,
+  };
+  return win;
+}
+
+const setup = (opts) => {
+  const win = fakeWindow(opts);
+  const onClose = vi.fn();
+  const ctl = createSheetController({ key: 'monthDaySheet', onClose, win });
+  ctl.open();
+  return { win, onClose, ctl };
+};
+
+describe('sheet dismissal controller', () => {
+  it('pushes a history entry on open so the browser and Android back close the sheet', () => {
+    const { win, onClose } = setup();
+    expect(win.history.pushState).toHaveBeenCalledTimes(1);
+    expect(win.history.state).toEqual({ monthDaySheet: true });
+    expect(onClose).not.toHaveBeenCalled();
+    win.fire('popstate', { state: null });
+    expect(onClose).toHaveBeenCalledWith('back');
+  });
+
+  it('pushes once even when opened twice on the same entry (StrictMode double effects)', () => {
+    const win = fakeWindow();
+    const first = createSheetController({ key: 'monthDaySheet', onClose: vi.fn(), win });
+    first.open(); first.dispose();
+    const onClose = vi.fn();
+    const second = createSheetController({ key: 'monthDaySheet', onClose, win });
+    second.open();
+    expect(win.history.pushState).toHaveBeenCalledTimes(1);
+    expect(win.history.entries).toHaveLength(1);
+    win.fire('keydown', { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(win.history.state).toBeNull(); // the stack is back where it started
+  });
+
+  it('closes on Escape by unwinding its own history entry, closing exactly once', () => {
+    const { win, onClose } = setup();
+    win.fire('keydown', { key: 'Escape' });
+    expect(win.history.back).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledWith('back');
+    expect(win.history.state).toBeNull();
+  });
+
+  it('ignores other keys, an already-handled Escape, and Escape while an inner overlay is open', () => {
+    const { win, onClose } = setup();
+    win.fire('keydown', { key: 'Enter' });
+    win.fire('keydown', { key: 'Escape', defaultPrevented: true });
+    expect(onClose).not.toHaveBeenCalled();
+    const inner = setup({ hasInnerOverlay: true });
+    inner.win.fire('keydown', { key: 'Escape' });
+    expect(inner.onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes directly when it never got a history entry (no history API)', () => {
+    const win = fakeWindow(); win.history = undefined;
+    const onClose = vi.fn();
+    const ctl = createSheetController({ key: 'k', onClose, win });
+    ctl.open();
+    ctl.dismiss('button');
+    expect(onClose).toHaveBeenCalledWith('button');
+  });
+
+  it('dismisses on a pull-down past the threshold, only from the top of the content', () => {
+    const { ctl, onClose } = setup();
+    ctl.onDragStart({ x: 100, y: 100, t: 0, scrollTop: 0 });
+    expect(ctl.onDragMove({ x: 102, y: 160, t: 80 })).toBe(60);
+    expect(ctl.onDragMove({ x: 104, y: 100 + SHEET_PULL_DISMISS_PX + 10, t: 300 })).toBe(SHEET_PULL_DISMISS_PX + 10);
+    expect(ctl.onDragEnd()).toBe(true);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const scrolled = setup();
+    scrolled.ctl.onDragStart({ x: 100, y: 100, t: 0, scrollTop: 240 });
+    expect(scrolled.ctl.onDragMove({ x: 100, y: 400, t: 300 })).toBe(0);
+    expect(scrolled.ctl.onDragEnd()).toBe(false);
+    expect(scrolled.onClose).not.toHaveBeenCalled();
+  });
+
+  it('dismisses on a quick short flick but not a slow short pull', () => {
+    expect(shouldDismissPull({ dy: 40, dtMs: 50, scrollTop: 0 })).toBe(true);
+    expect(shouldDismissPull({ dy: 40, dtMs: 600, scrollTop: 0 })).toBe(false);
+    expect(shouldDismissPull({ dy: -80, dtMs: 50, scrollTop: 0 })).toBe(false);
+    const quick = setup();
+    quick.ctl.onDragStart({ x: 50, y: 300, t: 0, scrollTop: 0 });
+    quick.ctl.onDragMove({ x: 50, y: 340, t: 40 }); // 1px/ms over 40px: a fling
+    expect(quick.ctl.onDragEnd()).toBe(true);
+    expect(quick.onClose).toHaveBeenCalledTimes(1);
+    const slow = setup();
+    slow.ctl.onDragStart({ x: 50, y: 300, t: 0, scrollTop: 0 });
+    slow.ctl.onDragMove({ x: 50, y: 340, t: 600 });
+    expect(slow.ctl.onDragEnd()).toBe(false);
+    expect(slow.onClose).not.toHaveBeenCalled();
+  });
+
+  it('dismisses on a left-edge swipe and nothing else horizontal', () => {
+    expect(shouldDismissEdgeSwipe({ startX: SHEET_EDGE_START_PX, dx: SHEET_EDGE_DISMISS_PX, dy: 10 })).toBe(true);
+    expect(shouldDismissEdgeSwipe({ startX: SHEET_EDGE_START_PX + 1, dx: 200, dy: 0 })).toBe(false);
+    expect(shouldDismissEdgeSwipe({ startX: 4, dx: 60, dy: 0 })).toBe(false);
+    expect(shouldDismissEdgeSwipe({ startX: 4, dx: 100, dy: 140 })).toBe(false);
+    const { ctl, onClose } = setup();
+    ctl.onDragStart({ x: 8, y: 300, t: 0, scrollTop: 500 }); // scrolled content does not matter for the edge
+    ctl.onDragMove({ x: 120, y: 310, t: 200 });
+    expect(ctl.onDragEnd()).toBe(true);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('never closes twice and stops listening on dispose', () => {
+    const { win, ctl, onClose } = setup();
+    ctl.dismiss('button');
+    ctl.dismiss('button');
+    win.fire('popstate', {});
+    expect(onClose).toHaveBeenCalledTimes(1);
+    ctl.dispose();
+    expect(win.listenerCount('popstate')).toBe(0);
+    expect(win.listenerCount('keydown')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Tapping a month cell now opens a bottom sheet showing that day's agenda, rendered by the existing SCHED view scoped to that single date. Same cards, same completion toggles, same edit affordances. No horizontal swipe between days and no grid selection syncing (step 5).

**Feasibility answer:** scoping SCHED by an optional date range was feasible without restructuring it. `useSchedAgendaState` takes an optional `{ dateRange }` and `SchedView` an optional `dateRange` plus `embedded` prop. Callers that pass nothing get the rolling window exactly as before (the scope test asserts the unscoped path). A scoped agenda always shows its days, has no overdue section, and hides "Empty days" and "Show more days".

## What changed

- **Sheet** (`src/components/month/MonthDaySheet.jsx`): 88% height on every platform, phone and desktop alike, content scrolls inside. Localized weekday/date title, visible close button, drag handle.
- **Dismissal** as one pure controller (`src/utils/sheetDismissal.js`) wired by `src/hooks/useSheetDismissal.js`:
  - Escape (web/Electron). Yields to a card's notes panel and to any handler that already called preventDefault.
  - Browser back: a history entry is pushed on open, popstate closes the sheet, and the month view stays underneath.
  - Android hardware/gesture back: the same history entry, popped by MainActivity's existing `webView.goBack()` path.
  - Pull-down from the top of the content (120px, or a fling), drag on the handle, everywhere.
  - Left-edge swipe (iOS has no free back gesture; it was cheap so it is in).
  - Backdrop tap and close button.
  - Every non-back path leaves through `history.back()` so the entry never lingers and a later back press cannot re-close a sheet that is gone. React StrictMode's double mount pushes only one entry.
- **Recurring expansion**: the month grid publishes its visible range as `monthViewRange` in the planner context, so recurring occurrences are expanded for every cell and for the sheet, not just the rolling SCHED window.
- **Stacking**: the dev overlay drops from z-80 to z-45 and the sheet sits at z-46, so the task editors (z-80) and the filter popup (z-50) that open from inside the sheet stack above it.
- A handle pointer-capture bug found in the browser check is fixed: the pointer is captured only once it moves, otherwise the click retargeted to the handle row and the close button was dead.

## Kiosk

Month view is not reachable in the Linux kiosk today. `?dial` mounts the Day Dial modal at z-70 over everything, and the month grid only exists behind the temporary dev flag. When the grid is routed through the view cycler (step 5 or later), gate that entry out while the dial/kiosk mode is active rather than teaching the sheet about kiosk.

## Tests

- `src/utils/sheetDismissal.test.js`: push on open, popstate close, Escape closes once through history, ignored keys and inner overlay, no-history fallback, pull threshold and scrollTop rule, fling vs slow pull, edge swipe, close-once/dispose, StrictMode double open.
- `src/components/sched/useSchedAgendaState.scope.test.jsx`: unscoped path unchanged, single-date scope, multi-day range order, incomplete range not scoped.
- `src/components/month/MonthDaySheet.test.jsx`: dialog and label, scoped SCHED, only that day's task, no window controls, empty day still offers "Add task", German title and close label.
- Browser check in Chromium at desktop and phone widths: open from a cell, Escape, browser back, backdrop, close button, mouse drag on the handle, touch pull-down (long pull closes, short pull snaps back), history state unwound after each.

Full suite: 3779 tests pass. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVzEXoUK2BrKm2Hcxeexpx)_